### PR TITLE
Replace v-t directive with $t() usage

### DIFF
--- a/databrowser/src/domain/auth/UserAuthentication.vue
+++ b/databrowser/src/domain/auth/UserAuthentication.vue
@@ -3,8 +3,8 @@
     {{ user?.email }}<button @click="onLogout">Logout</button>
   </div>
   <div v-else>
-    <button v-t="'auth.login'" @click="onLogin" />
-    <button v-t="'auth.register'" @click="onRegister" />
+    <button @click="onLogin">{{ $t('auth.login') }}</button>
+    <button @click="onRegister">{{ $t('auth.register') }}</button>
   </div>
 </template>
 


### PR DESCRIPTION
The translation library vue-i18n provides a directive v-t that can be
used for translations. Unfortunately that directive has issues when
the translations are loaded asynchronosly and if the locale is changed
on-the-fly in the app. It is also denoted by the vue-i18n documentation
that the v-t directive is complex (see
https://vue-i18n.intlify.dev/guide/advanced/directive.html#t-vs-v-t).
Most probably the problems are caused by v-t doing some compilation
steps to improve performance.

The suggested fix is to don't use the v-t directive and to use the $t()
function instead as that function works as intended.