### PR TITLE
Add role nullcheck

### DIFF
--- a/databrowser/src/domain/auth/store/auth.ts
+++ b/databrowser/src/domain/auth/store/auth.ts
@@ -24,7 +24,7 @@ export const useAuth = defineStore('auth', {
       }
     },
     hasRole(state) {
-      return (role: string) => this.user?.roles.includes(role) ?? false;
+      return (role: string) => this.user?.roles?.includes(role) ?? false;
     },
     hasAnyRole(state) {
       return (roles: string[]) =>


### PR DESCRIPTION
Added an additional nullcheck as the bearer token of a newly created account doesn't even include the roles field.