### PR TITLE
District Detail View changes, new GPS Data implementation on Detail Views, new ExperienceArea Detail View and small fixes

### DIFF
--- a/databrowser/src/config/config.ts
+++ b/databrowser/src/config/config.ts
@@ -24,6 +24,7 @@ import {
   measuringPointConfig,
   snowReportConfig,
   eventConfig,
+  experienceAreaConfig,
 } from './tourism';
 
 type EmbeddedDatasetConfigs = Record<
@@ -56,6 +57,7 @@ const datasetConfigs = [
   measuringPointConfig,
   snowReportConfig,
   eventConfig,
+  experienceAreaConfig,
 ];
 
 const computeEmbeddedDatasetConfigs = (): EmbeddedDatasetConfigs => {

--- a/databrowser/src/config/tourism/district/district.detailView.ts
+++ b/databrowser/src/config/tourism/district/district.detailView.ts
@@ -171,77 +171,6 @@ export const districtDetailView: DetailViewConfig = {
       ],
     },
     {
-      name: 'Contact',
-      slug: 'contact',
-      subcategories: [
-        {
-          name: 'Name and Company Data',
-          properties: [
-            {
-              title: 'Name',
-              component: CellComponent.StringCell,
-              fields: { text: 'AccoDetail.{language}.Name' },
-            },
-            {
-              title: 'First Name',
-              component: CellComponent.StringCell,
-              fields: { text: 'AccoDetail.{language}.Firstname' },
-            },
-            {
-              title: 'Surname',
-              component: CellComponent.StringCell,
-              fields: { text: 'AccoDetail.{language}.Lastname' },
-            },
-          ],
-        },
-        {
-          name: 'Address',
-          properties: [
-            {
-              title: 'Street and House No',
-              component: CellComponent.StringCell,
-              fields: { text: 'AccoDetail.{language}.Street' },
-            },
-            {
-              title: 'ZIP-Code',
-              component: CellComponent.StringCell,
-              fields: { text: 'AccoDetail.{language}.Zip' },
-            },
-            {
-              title: 'City',
-              component: CellComponent.StringCell,
-              fields: { text: 'AccoDetail.{language}.City' },
-            },
-            {
-              title: 'Country Abbrevation',
-              component: CellComponent.StringCell,
-              fields: { text: 'AccoDetail.{language}.CountryCode' },
-            },
-          ],
-        },
-        {
-          name: 'Contact Details',
-          properties: [
-            {
-              title: 'E-Mail',
-              component: CellComponent.StringCell,
-              fields: { text: 'AccoDetail.{language}.Email' },
-            },
-            {
-              title: 'Phone Number',
-              component: CellComponent.StringCell,
-              fields: { text: 'AccoDetail.{language}.Phone' },
-            },
-            {
-              title: 'Web-URL',
-              component: CellComponent.StringCell,
-              fields: { text: 'AccoDetail.{language}.Website' },
-            },
-          ],
-        },
-      ],
-    },
-    {
       name: 'Images',
       slug: 'images',
       subcategories: [
@@ -255,7 +184,7 @@ export const districtDetailView: DetailViewConfig = {
                 images: 'ImageGallery',
               },
               params: {
-                alt: 'ImageAltText.{language}',
+                alt: 'ImageTitle.{language}',
                 src: 'ImageUrl',
                 name: 'ImageName',
                 width: 'Width',
@@ -281,24 +210,12 @@ export const districtDetailView: DetailViewConfig = {
             {
               title: 'Region / TVB',
               component: CellComponent.StringCell,
-              fields: { text: 'LocationInfo.RegionInfo.Name.{language}' },
+              fields: { text: 'Region.Id' },
             },
             {
-              title: 'Tourismorganization',
+              title: 'Municipality',
               component: CellComponent.StringCell,
-              fields: { text: 'TourismorganizationId' },
-            },
-            {
-              title: 'district',
-              component: CellComponent.StringCell,
-              fields: {
-                text: 'LocationInfo.districtInfo.Name.{language}',
-              },
-            },
-            {
-              title: 'District',
-              component: CellComponent.StringCell,
-              fields: { text: 'LocationInfo.DistrictInfo.Name.{language}' },
+              fields: { text: 'Municipality.Id' },
             },
           ],
         },

--- a/databrowser/src/config/tourism/district/district.detailView.ts
+++ b/databrowser/src/config/tourism/district/district.detailView.ts
@@ -236,17 +236,12 @@ export const districtDetailView: DetailViewConfig = {
             {
               title: 'Latitude',
               component: CellComponent.StringCell,
-              fields: { text: 'GpsPoints.Latitude' },
+              fields: { text: 'GpsPoints.position.Latitude' },
             },
             {
               title: 'Longitude',
               component: CellComponent.StringCell,
               fields: { text: 'GpsPoints.position.Longitude' },
-            },
-            {
-              title: 'Altitude',
-              component: CellComponent.StringCell,
-              fields: { text: 'GpsPoints.position.Altitude' },
             },
             {
               title: 'Altitude',

--- a/databrowser/src/config/tourism/district/district.detailView.ts
+++ b/databrowser/src/config/tourism/district/district.detailView.ts
@@ -221,5 +221,73 @@ export const districtDetailView: DetailViewConfig = {
         },
       ],
     },
+    {
+      name: 'GPS Data',
+      slug: 'GPS Data',
+      subcategories: [
+        {
+          name: 'GPS Data',
+          properties: [
+            {
+              title: 'GPS Type',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.Gpstype' },
+            },
+            {
+              title: 'Latitude',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.Latitude' },
+            },
+            {
+              title: 'Longitude',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.Longitude' },
+            },
+            {
+              title: 'Altitude',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.Altitude' },
+            },
+            {
+              title: 'Altitude',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.Altitude' },
+            },
+            {
+              title: 'Altitude Unit',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.AltitudeUnitofMeasure' },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'Tags',
+      slug: 'tags',
+      subcategories: [
+        {
+          name: 'Tags',
+          properties: [
+            {
+              title: 'ODH Tags',
+              component: CellComponent.ArrayCellTags,
+              class: 'w-40',
+              fields: {
+                items: 'ODHTags',
+              },
+            },
+            {
+              title: 'SMG Tags',
+              component: CellComponent.ArrayCellTags,
+              class: 'w-40',
+              fields: {
+                items: 'SmgTags',
+              },
+            },
+          ],
+        },
+      ],
+    },
   ],
 };

--- a/databrowser/src/config/tourism/experienceArea/experienceArea.config.ts
+++ b/databrowser/src/config/tourism/experienceArea/experienceArea.config.ts
@@ -1,0 +1,15 @@
+import { DatasetConfig } from '../../../domain/datasetConfig/types';
+import { domains } from '../../../domain/openApi';
+import { experienceAreaOperations } from './experienceArea.operations';
+import { experienceAreaDescription } from './experienceArea.description';
+import { experienceAreaViews } from './experienceArea.views';
+import { experienceAreaRoute } from './experienceArea.route';
+
+export const experienceAreaConfig: DatasetConfig = {
+  source: 'embedded',
+  baseUrl: domains.tourism.baseUrl,
+  route: experienceAreaRoute,
+  description: experienceAreaDescription,
+  views: experienceAreaViews,
+  operations: experienceAreaOperations,
+};

--- a/databrowser/src/config/tourism/experienceArea/experienceArea.description.ts
+++ b/databrowser/src/config/tourism/experienceArea/experienceArea.description.ts
@@ -1,0 +1,5 @@
+import { DatasetDescription } from '../../../domain/datasetConfig/types';
+
+export const experienceAreaDescription: DatasetDescription = {
+  title: 'Experience Area',
+};

--- a/databrowser/src/config/tourism/experienceArea/experienceArea.detailView.ts
+++ b/databrowser/src/config/tourism/experienceArea/experienceArea.detailView.ts
@@ -1,0 +1,294 @@
+import { DetailViewConfig } from '../../../domain/datasetConfig/types';
+import { CellComponent } from '../../../domain/cellComponents/types';
+
+export const experienceAreaDetailView: DetailViewConfig = {
+  elements: [
+    {
+      name: 'Main data',
+      slug: 'main-data',
+      subcategories: [
+        {
+          name: 'General data',
+          properties: [
+            {
+              title: 'Shortname',
+              component: CellComponent.StringCell,
+              fields: { text: 'Shortname' },
+            },
+            {
+              title: 'Image',
+              component: CellComponent.ImageCell,
+              class: 'w-40',
+              fields: {
+                src: 'ImageGallery.0.ImageUrl',
+              },
+            },
+          ],
+        },
+        {
+          name: 'IDs',
+          properties: [
+            {
+              title: 'ID',
+              component: CellComponent.StringCell,
+              fields: { text: 'Id' },
+              class: 'break-all',
+            },
+            {
+              title: 'Custom Id',
+              component: CellComponent.StringCell,
+              fields: { text: 'CustomId' },
+              class: 'break-all',
+            },
+            {
+              title: 'Company Id',
+              component: CellComponent.StringCell,
+              fields: { text: 'CompanyId' },
+              class: 'break-all',
+            },
+            {
+              title: 'Tourismverein IDs',
+              component: CellComponent.ArrayCell,
+              class: 'w-40',
+              fields: {
+                items: 'TourismvereinIds',
+              },
+              params: {
+                separator: ', ',
+              },
+            },
+            {
+              title: 'District IDs',
+              component: CellComponent.ArrayCell,
+              class: 'w-40',
+              fields: {
+                items: 'DistrictIds',
+              },
+              params: {
+                separator: ', ',
+              },
+            },
+          ],
+        },
+        {
+          name: 'Data states',
+          properties: [
+            {
+              title: 'Last Changes',
+              component: CellComponent.DateCell,
+              fields: { date: 'LastChange' },
+              params: {
+                format: 'd/M/yyyy HH:mm',
+              },
+            },
+            {
+              title: 'Active',
+              component: CellComponent.StringCell,
+              fields: { text: 'Active' },
+            },
+            {
+              title: 'Active on SMG',
+              component: CellComponent.StringCell,
+              fields: { text: 'SmgActive' },
+            },
+            {
+              title: 'Active on ODH',
+              component: CellComponent.StringCell,
+              fields: { text: 'OdhActive' },
+            },
+            {
+              title: 'Visible in Search',
+              component: CellComponent.StringCell,
+              fields: { text: 'VisibleInSearch' },
+            },
+          ],
+        },
+        {
+          name: 'Source',
+          properties: [
+            {
+              title: 'Source',
+              component: CellComponent.StringCell,
+              fields: { text: 'Source' },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'Text information',
+      slug: 'text-information',
+      subcategories: [
+        {
+          name: 'General data',
+          properties: [
+            {
+              title: 'Meta Title',
+              component: CellComponent.StringCell,
+              fields: { text: 'Detail.{language}.MetaTitle' },
+            },
+            {
+              title: 'Description',
+              component: CellComponent.StringCell,
+              fields: { text: 'Detail.{language}.MetaDesc' },
+            },
+            {
+              title: 'Title',
+              component: CellComponent.StringCell,
+              fields: { text: 'Detail.{language}.Title' },
+            },
+            {
+              title: 'Header',
+              component: CellComponent.StringCell,
+              fields: { text: 'Detail.{language}.Header' },
+            },
+            {
+              title: 'Subheader',
+              component: CellComponent.StringCell,
+              fields: { text: 'Detail.{language}.Subheader' },
+            },
+            {
+              title: 'Intro Text',
+              component: CellComponent.StringCell,
+              fields: { text: 'Detail.{language}.IntroText' },
+            },
+            {
+              title: 'Base Text',
+              component: CellComponent.StringCell,
+              fields: { text: 'Detail.{language}.BaseText' },
+            },
+            {
+              title: 'Additional Text',
+              component: CellComponent.StringCell,
+              fields: { text: 'Detail.{language}.AdditionalText' },
+            },
+            {
+              title: 'There Text',
+              component: CellComponent.StringCell,
+              fields: { text: 'Detail.{language}.GetThereText' },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'Images',
+      slug: 'images',
+      subcategories: [
+        {
+          name: 'Images',
+          properties: [
+            {
+              title: '',
+              component: CellComponent.ImageGalleryCell,
+              fields: {
+                images: 'ImageGallery',
+              },
+            },
+            {
+              title: 'License',
+              component: CellComponent.StringCell,
+              fields: { text: 'LicenseInfo.License' },
+            },
+            {
+              title: 'License Holder',
+              component: CellComponent.StringCell,
+              fields: { text: 'LicenseInfo.LicenseHolder' },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'Location',
+      slug: 'location',
+      subcategories: [
+        {
+          name: 'Locations',
+          properties: [
+            {
+              title: 'Districts',
+              component: CellComponent.ArrayCell,
+              class: 'w-40',
+              fields: {
+                items: 'Districts',
+              },
+              params: {
+                separator: ', ',
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'GPS Data',
+      slug: 'gps Data',
+      subcategories: [
+        {
+          name: 'GPS Data',
+          properties: [
+            {
+              title: 'Gpstype',
+              component: CellComponent.StringCell,
+              fields: { text: 'Gpstype' },
+            },
+            {
+              title: 'Latitude',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.Latitude' },
+            },
+            {
+              title: 'Longitude',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.Longitude' },
+            },
+            {
+              title: 'Altitude',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.Altitude' },
+            },
+            {
+              title: 'Altitude Unit',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.AltitudeUnitofMeasure' },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'Tags',
+      slug: 'tags',
+      subcategories: [
+        {
+          name: 'Tags',
+          properties: [
+            {
+              title: 'SMG Tags',
+              component: CellComponent.ArrayCell,
+              class: 'w-40',
+              fields: {
+                items: 'SmgTags',
+              },
+              params: {
+                separator: ', ',
+              },
+            },
+            {
+              title: 'ODH Tags',
+              component: CellComponent.ArrayCell,
+              class: 'w-40',
+              fields: {
+                items: 'ODHTags',
+              },
+              params: {
+                separator: ', ',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/databrowser/src/config/tourism/experienceArea/experienceArea.listView.ts
+++ b/databrowser/src/config/tourism/experienceArea/experienceArea.listView.ts
@@ -1,0 +1,9 @@
+import { ListViewConfig } from '../../../domain/datasetConfig/types';
+import {
+  CellComponent,
+  FilterComponent,
+} from '../../../domain/cellComponents/types';
+
+export const experienceAreaListView: ListViewConfig = {
+  elements: [],
+};

--- a/databrowser/src/config/tourism/experienceArea/experienceArea.operations.ts
+++ b/databrowser/src/config/tourism/experienceArea/experienceArea.operations.ts
@@ -1,0 +1,34 @@
+import { Operations } from '../../../domain/datasetConfig/types';
+import {
+  extendCreateRoles,
+  extendDeleteRoles,
+  extendUpdateRoles,
+  ROLE_READ,
+} from '../roles';
+
+export const experienceAreaOperations: Operations = {
+  readAll: {
+    rolesAllowed: ROLE_READ,
+  },
+  read: {
+    rolesAllowed: ROLE_READ,
+  },
+  create: {
+    rolesAllowed: extendCreateRoles([
+      'ExperienceAreaManager',
+      'ExperienceAreaCreate',
+    ]),
+  },
+  update: {
+    rolesAllowed: extendUpdateRoles([
+      'ExperienceAreaManager',
+      'ExperienceAreaUpdate',
+    ]),
+  },
+  delete: {
+    rolesAllowed: extendDeleteRoles([
+      'ExperienceAreaManager',
+      'ExperienceAreaDelete',
+    ]),
+  },
+};

--- a/databrowser/src/config/tourism/experienceArea/experienceArea.route.ts
+++ b/databrowser/src/config/tourism/experienceArea/experienceArea.route.ts
@@ -1,0 +1,6 @@
+import { DatasetRoute } from '../../../domain/datasetConfig/types';
+
+export const experienceAreaRoute: DatasetRoute = {
+  domain: 'tourism',
+  pathParams: ['v1', 'ExperienceArea'],
+};

--- a/databrowser/src/config/tourism/experienceArea/experienceArea.views.ts
+++ b/databrowser/src/config/tourism/experienceArea/experienceArea.views.ts
@@ -1,0 +1,7 @@
+import { experienceAreaListView } from './experienceArea.listView';
+import { experienceAreaDetailView } from './experienceArea.detailView';
+
+export const experienceAreaViews = {
+  table: experienceAreaListView,
+  detail: experienceAreaDetailView,
+};

--- a/databrowser/src/config/tourism/index.ts
+++ b/databrowser/src/config/tourism/index.ts
@@ -22,3 +22,4 @@ export { skiAreaConfig } from './skiArea/skiArea.config';
 export { measuringPointConfig } from './measuringPoint/measuringPoint.config';
 export { snowReportConfig } from './snowReport/snowReport.config';
 export { eventConfig } from './event/event.config';
+export { experienceAreaConfig } from './experienceArea/experienceArea.config';

--- a/databrowser/src/config/tourism/snowReport/snowReport.route.ts
+++ b/databrowser/src/config/tourism/snowReport/snowReport.route.ts
@@ -2,5 +2,5 @@ import { DatasetRoute } from '../../../domain/datasetConfig/types';
 
 export const snowReportRoute: DatasetRoute = {
   domain: 'tourism',
-  pathParams: ['v1', 'Weather', 'snowReport'],
+  pathParams: ['v1', 'Weather', 'SnowReport'],
 };

--- a/databrowser/src/config/tourism/webcamInfo/webcamInfo.detailView.ts
+++ b/databrowser/src/config/tourism/webcamInfo/webcamInfo.detailView.ts
@@ -89,17 +89,12 @@ export const webcamInfoDetailView: DetailViewConfig = {
             {
               title: 'Latitude',
               component: CellComponent.StringCell,
-              fields: { text: 'GpsPoints.Latitude' },
+              fields: { text: 'GpsPoints.position.Latitude' },
             },
             {
               title: 'Longitude',
               component: CellComponent.StringCell,
               fields: { text: 'GpsPoints.position.Longitude' },
-            },
-            {
-              title: 'Altitude',
-              component: CellComponent.StringCell,
-              fields: { text: 'GpsPoints.position.Altitude' },
             },
             {
               title: 'Altitude',

--- a/databrowser/src/config/tourism/webcamInfo/webcamInfo.detailView.ts
+++ b/databrowser/src/config/tourism/webcamInfo/webcamInfo.detailView.ts
@@ -82,17 +82,34 @@ export const webcamInfoDetailView: DetailViewConfig = {
           name: 'GPS Data',
           properties: [
             {
-              title: '',
-              component: CellComponent.GpsListCell,
-              class: 'w-40',
-              fields: { gpsEntries: 'GpsInfos' },
-              params: {
-                type: 'Gpstype',
-                latitude: 'Latitude',
-                longitude: 'Longitude',
-                altitude: 'Altitude',
-                altitudeUnit: 'AltitudeUnitofMeasure',
-              },
+              title: 'GPS Type',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.Gpstype' },
+            },
+            {
+              title: 'Latitude',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.Latitude' },
+            },
+            {
+              title: 'Longitude',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.Longitude' },
+            },
+            {
+              title: 'Altitude',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.Altitude' },
+            },
+            {
+              title: 'Altitude',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.Altitude' },
+            },
+            {
+              title: 'Altitude Unit',
+              component: CellComponent.StringCell,
+              fields: { text: 'GpsPoints.position.AltitudeUnitofMeasure' },
             },
           ],
         },


### PR DESCRIPTION
@gappc With this PR I used another way to Implement the GPS Data in the Detail View. You can check it in the District DetailView config file. I think that in this way we don't need to develop a new component for GPS Data.

Honestly, it was an obvious one, and I don't know how we didn't see it before. Anyway, let me know if this solution is ideal. If so, I can start adding GPS Data in all the DetailViews config files.