### PR TITLE
fix acronyms ODH and keep descriptions generic

### DIFF
--- a/databrowser/src/config/config-for-pages.ts
+++ b/databrowser/src/config/config-for-pages.ts
@@ -22,7 +22,7 @@ export const datasetsForPages: Record<SupportedDomains, DatasetDescription[]> =
         id: 'articles',
         title: 'Articles',
         description:
-          'This dataset contains articles such as recipes, books, catalogues, guides about South Tyrol. It contains Historical data. Only recipes are still updated.',
+          'This dataset contains articles such as recipes, books, catalogues and guides. It contains Historical data. Only recipes are still updated.',
         output: 'JSON, mime-type application/json',
         apiVersion: 'v1',
         swaggerUrl:
@@ -67,7 +67,7 @@ export const datasetsForPages: Record<SupportedDomains, DatasetDescription[]> =
         id: 'locations',
         title: 'Locations',
         description:
-          'These datasets contain Location & Commons Data API of Tourism Regions of South Tyrol. ID Lists of Regions, Tourism Associations, Areas, Municipalities, Ski Areas. Data provided by IDM.',
+          'These datasets contain Location & Commons Data API of Tourism Regions. ID Lists of Regions, Tourism Associations, Areas, Municipalities, Ski Areas. Data provided by IDM.',
         output: 'JSON, mime-type application/json',
         apiVersion: 'v1',
         swaggerUrl:
@@ -82,7 +82,7 @@ export const datasetsForPages: Record<SupportedDomains, DatasetDescription[]> =
         id: 'snow-report',
         title: 'Snow Report',
         description:
-          'Snow Report Data dataset contains detailed report of all South Tyrolean Ski Areas. Lifts, Slopes, Ski tracks, Sledges (status and conditions) data provided by LTS (daily updated), Measuring points (snow height, last snow day) data provided by LTS (daily updated), Ski Areas basic data provided by IDM.',
+          'Snow Report Data dataset contains detailed report of Ski Areas. Lifts, Slopes, Ski tracks, Sledges (status and conditions) data provided by LTS (daily updated), Measuring points (snow height, last snow day) data provided by LTS (daily updated), Ski Areas basic data provided by IDM.',
         output: 'JSON, mime-type application/json',
         apiVersion: 'v1',
         swaggerUrl:
@@ -113,7 +113,7 @@ export const datasetsForPages: Record<SupportedDomains, DatasetDescription[]> =
         id: 'weather-forecast',
         title: 'Weather Forecast',
         description:
-          'South Tyrolean Weather Information general. Updated at 07:00 and 11:00. South Tyrolean Weather Details for today, tomorrow, Mountain weather today, tomorrow, Station weather today, tomorrow and 5 days evolution. All data is requested live through the Weather service of the province BZ. Data available in languages de, it, en.',
+          'General Weather Information. Updated at 07:00 and 11:00. Weather Details for today, tomorrow, Mountain weather today, tomorrow, Station weather today, tomorrow and 5 days evolution. All data is requested live through the Weather service of the province BZ. Data available in languages de, it, en.',
         output: 'JSON, mime-type application/json',
         apiVersion: 'v1',
         swaggerUrl:
@@ -128,7 +128,7 @@ export const datasetsForPages: Record<SupportedDomains, DatasetDescription[]> =
         id: 'accommodations',
         title: 'Accommodations',
         description:
-          'This dataset contains accommodations in South Tyrol. Accessible via REST or the AlpineBits HotelData open standard.',
+          'This dataset contains accommodations. Accessible via REST or the AlpineBits HotelData open standard.',
         output: 'JSON, mime-type application/json, XML AlpineBits',
         apiVersion: 'v1',
         swaggerUrl:
@@ -158,7 +158,7 @@ export const datasetsForPages: Record<SupportedDomains, DatasetDescription[]> =
         id: 'activities-pois-gastronomy',
         title: 'Activities, Pois & Gastronomy',
         description:
-          'This dataset contains a collection of activities and points of interest (PoI) and gastronomy locations (such as restaurants, bars, alpine huts, etc.) in the South Tyrol region. The available data have been extracted from different sources such as SIAG South Tyrolean museums, Südtirol Wein, Dolomiti Superski, LTS, IDM created content.',
+          'This dataset contains a collection of activities and points of interest (PoI) and gastronomy locations (such as restaurants, bars, alpine huts, etc.). The available data have been extracted from different sources such as SIAG South Tyrolean museums, Südtirol Wein, Dolomiti Superski, LTS, IDM created content.',
         output: 'JSON, mime-type application/json',
         apiVersion: 'v1',
         swaggerUrl:

--- a/databrowser/src/config/tourism/accommodation/accommodation.description.ts
+++ b/databrowser/src/config/tourism/accommodation/accommodation.description.ts
@@ -3,6 +3,5 @@ import { DatasetDescription } from '../../../domain/datasetConfig/types';
 export const accommodationDescription: DatasetDescription = {
   title: 'Accommodation',
   subtitle: 'This dataset contains tourism accommodations.',
-  description:
-    'This dataset contains various data about accommodations, mainly located in the South Tyrol region.',
+  description: 'This dataset contains various data about accommodations.',
 };

--- a/databrowser/src/config/tourism/accommodation/accommodation.detailView.ts
+++ b/databrowser/src/config/tourism/accommodation/accommodation.detailView.ts
@@ -177,7 +177,7 @@ export const accommodationDetailView: DetailViewConfig = {
               fields: { text: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -408,10 +408,10 @@ export const accommodationDetailView: DetailViewConfig = {
       slug: 'tags',
       subcategories: [
         {
-          name: 'ODH Tags',
+          name: 'Open Data Hub Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/accommodation/accommodation.listView.ts
+++ b/databrowser/src/config/tourism/accommodation/accommodation.listView.ts
@@ -75,7 +75,7 @@ export const accommodationListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/article/article.description.ts
+++ b/databrowser/src/config/tourism/article/article.description.ts
@@ -3,7 +3,7 @@ import { DatasetDescription } from '../../../domain/datasetConfig/types';
 export const articleDescription: DatasetDescription = {
   title: 'Articles',
   subtitle:
-    'This dataset contains articles such as recipes, books, catalogues, guides about South Tyrol.',
+    'This dataset contains articles such as recipes, books, catalogues and guides',
   description:
-    'This dataset contains articles such as recipes, books, catalogues, guides about South Tyrol. It contains Historical data. Only recipes are still updated.',
+    'This dataset contains articles such as recipes, books, catalogues, and guides. It contains Historical data. Only recipes are still updated.',
 };

--- a/databrowser/src/config/tourism/article/article.detailView.ts
+++ b/databrowser/src/config/tourism/article/article.detailView.ts
@@ -101,7 +101,7 @@ export const articleDetailView: DetailViewConfig = {
               fields: { text: 'SmgActive' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -255,10 +255,10 @@ export const articleDetailView: DetailViewConfig = {
       slug: 'tags',
       subcategories: [
         {
-          name: 'ODH Tags',
+          name: 'Open Data Hub Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/article/article.editView.ts
+++ b/databrowser/src/config/tourism/article/article.editView.ts
@@ -56,7 +56,7 @@ export const articleEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.ToggleCell,
               fields: { enabled: 'OdhActive' },
             },

--- a/databrowser/src/config/tourism/article/article.listView.ts
+++ b/databrowser/src/config/tourism/article/article.listView.ts
@@ -91,7 +91,7 @@ export const articleListView: ListViewConfig = {
       fields: { text: 'PublishedOn.0' },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/district/district.detailView.ts
+++ b/databrowser/src/config/tourism/district/district.detailView.ts
@@ -91,7 +91,7 @@ export const districtDetailView: DetailViewConfig = {
               fields: { text: 'SmgActive' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -257,7 +257,7 @@ export const districtDetailView: DetailViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/district/district.editView.ts
+++ b/databrowser/src/config/tourism/district/district.editView.ts
@@ -91,7 +91,7 @@ export const districtEditView: EditViewConfig = {
               fields: { enabled: 'SmgActive' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.ToggleCell,
               fields: { enabled: 'OdhActive' },
               params: { preventChange: 'true' },
@@ -258,7 +258,7 @@ export const districtEditView: EditViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/district/district.listView.ts
+++ b/databrowser/src/config/tourism/district/district.listView.ts
@@ -42,7 +42,7 @@ export const districtListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/event/event.detailView.ts
+++ b/databrowser/src/config/tourism/event/event.detailView.ts
@@ -84,7 +84,7 @@ export const eventDetailView: DetailViewConfig = {
               fields: { text: 'SmgActive' },
             },
             {
-              title: 'ODH Active',
+              title: 'Open Data Hub Active',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -247,7 +247,7 @@ export const eventDetailView: DetailViewConfig = {
               fields: { text: 'SmgTags' },
             },
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCell,
               fields: { text: 'ODHTags' },
             },

--- a/databrowser/src/config/tourism/event/event.editView.ts
+++ b/databrowser/src/config/tourism/event/event.editView.ts
@@ -45,7 +45,7 @@ export const eventEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.ToggleCell,
               fields: { enabled: 'OdhActive' },
             },

--- a/databrowser/src/config/tourism/event/event.listView.ts
+++ b/databrowser/src/config/tourism/event/event.listView.ts
@@ -123,7 +123,7 @@ export const eventListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-40',
       fields: {

--- a/databrowser/src/config/tourism/eventShort/eventShort.listView.ts
+++ b/databrowser/src/config/tourism/eventShort/eventShort.listView.ts
@@ -105,7 +105,7 @@ export const eventShortListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/experienceArea/experienceArea.detailView.ts
+++ b/databrowser/src/config/tourism/experienceArea/experienceArea.detailView.ts
@@ -92,7 +92,7 @@ export const experienceAreaDetailView: DetailViewConfig = {
               fields: { text: 'SmgActive' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -263,7 +263,7 @@ export const experienceAreaDetailView: DetailViewConfig = {
               },
             },
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCell,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/experienceArea/experienceArea.listView.ts
+++ b/databrowser/src/config/tourism/experienceArea/experienceArea.listView.ts
@@ -50,7 +50,7 @@ export const experienceAreaListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/gastronomy/gastronomy.description.ts
+++ b/databrowser/src/config/tourism/gastronomy/gastronomy.description.ts
@@ -4,5 +4,5 @@ export const gastronomyDescription: DatasetDescription = {
   title: 'Gastronomy',
   subtitle: 'This dataset contains gastronomy locations.',
   description:
-    'This dataset contains a collection of gastronomy locations (such as restaurants, bars, alpine huts, etc.) in the South Tyrol region. ',
+    'This dataset contains a collection of gastronomy locations (such as restaurants, bars, alpine huts, etc.). ',
 };

--- a/databrowser/src/config/tourism/gastronomy/gastronomy.detailView.ts
+++ b/databrowser/src/config/tourism/gastronomy/gastronomy.detailView.ts
@@ -131,7 +131,7 @@ export const gastronomyDetailView: DetailViewConfig = {
               fields: { text: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -408,7 +408,7 @@ export const gastronomyDetailView: DetailViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/gastronomy/gastronomy.editView.ts
+++ b/databrowser/src/config/tourism/gastronomy/gastronomy.editView.ts
@@ -131,7 +131,7 @@ export const gastronomyEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -408,7 +408,7 @@ export const gastronomyEditView: EditViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/gastronomy/gastronomy.listView.ts
+++ b/databrowser/src/config/tourism/gastronomy/gastronomy.listView.ts
@@ -72,7 +72,7 @@ export const gastronomyListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/measuringPoint/measuringPoint.listView.ts
+++ b/databrowser/src/config/tourism/measuringPoint/measuringPoint.listView.ts
@@ -75,7 +75,7 @@ export const measuringPointListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/metaRegion/metaRegion.detailView.ts
+++ b/databrowser/src/config/tourism/metaRegion/metaRegion.detailView.ts
@@ -95,7 +95,7 @@ export const metaRegionDetailView: DetailViewConfig = {
               fields: { text: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -258,7 +258,7 @@ export const metaRegionDetailView: DetailViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/metaRegion/metaRegion.editView.ts
+++ b/databrowser/src/config/tourism/metaRegion/metaRegion.editView.ts
@@ -95,7 +95,7 @@ export const metaRegionEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -258,7 +258,7 @@ export const metaRegionEditView: EditViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/metaRegion/metaRegion.listView.ts
+++ b/databrowser/src/config/tourism/metaRegion/metaRegion.listView.ts
@@ -50,7 +50,7 @@ export const metaRegionListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/municipality/municipality.detailView.ts
+++ b/databrowser/src/config/tourism/municipality/municipality.detailView.ts
@@ -108,7 +108,7 @@ export const municipalityDetailView: DetailViewConfig = {
               fields: { text: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -271,7 +271,7 @@ export const municipalityDetailView: DetailViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/municipality/municipality.editView.ts
+++ b/databrowser/src/config/tourism/municipality/municipality.editView.ts
@@ -108,7 +108,7 @@ export const municipalityEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -271,7 +271,7 @@ export const municipalityEditView: EditViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/municipality/municipality.listView.ts
+++ b/databrowser/src/config/tourism/municipality/municipality.listView.ts
@@ -62,7 +62,7 @@ export const municipalityListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/odhActivityPoi/odhActivityPoi.description.ts
+++ b/databrowser/src/config/tourism/odhActivityPoi/odhActivityPoi.description.ts
@@ -5,5 +5,5 @@ export const odhActivityPoiDescription: DatasetDescription = {
   subtitle:
     'This dataset contains a collection of activities and points of interest (POIs).',
   description:
-    'This dataset contains a collection of activities and points of interest (PoI) and gastronomy locations (such as restaurants, bars, alpine huts, etc.) in the South Tyrol region. The available data have been extracted from different sources such as SIAG South Tyrolean museums,Südtirol Wein, Dolomiti Superski, LTS, IDM created content. ',
+    'This dataset contains a collection of activities and points of interest (PoI) and gastronomy locations (such as restaurants, bars, alpine huts, etc.). The available data have been extracted from different sources such as SIAG South Tyrolean museums,Südtirol Wein, Dolomiti Superski, LTS, IDM created content. ',
 };

--- a/databrowser/src/config/tourism/odhActivityPoi/odhActivityPoi.detailView.ts
+++ b/databrowser/src/config/tourism/odhActivityPoi/odhActivityPoi.detailView.ts
@@ -252,7 +252,7 @@ export const odhActivityPoiDetailView: DetailViewConfig = {
               fields: { text: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -615,10 +615,10 @@ export const odhActivityPoiDetailView: DetailViewConfig = {
       slug: 'tags',
       subcategories: [
         {
-          name: 'ODH Tags',
+          name: 'Open Data Hub Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/odhActivityPoi/odhActivityPoi.editView.ts
+++ b/databrowser/src/config/tourism/odhActivityPoi/odhActivityPoi.editView.ts
@@ -57,7 +57,7 @@ export const odhActivityPoiEditView: EditViewConfig = {
               fields: { text: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },

--- a/databrowser/src/config/tourism/odhActivityPoi/odhActivityPoi.listView.ts
+++ b/databrowser/src/config/tourism/odhActivityPoi/odhActivityPoi.listView.ts
@@ -149,7 +149,7 @@ export const odhActivityPoiListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-40',
       fields: {

--- a/databrowser/src/config/tourism/region/region.description.ts
+++ b/databrowser/src/config/tourism/region/region.description.ts
@@ -2,6 +2,6 @@ import { DatasetDescription } from '../../../domain/datasetConfig/types';
 
 export const regionDescription: DatasetDescription = {
   title: 'Region',
-  subtitle: 'This dataset contains South Tyrolean regions',
-  description: 'This dataset contains South Tyrolean regions',
+  subtitle: 'This dataset contains regions',
+  description: 'This dataset contains regions',
 };

--- a/databrowser/src/config/tourism/region/region.detailView.ts
+++ b/databrowser/src/config/tourism/region/region.detailView.ts
@@ -91,7 +91,7 @@ export const regionDetailView: DetailViewConfig = {
               fields: { text: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -345,7 +345,7 @@ export const regionDetailView: DetailViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/region/region.editView.ts
+++ b/databrowser/src/config/tourism/region/region.editView.ts
@@ -91,7 +91,7 @@ export const regionEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -345,7 +345,7 @@ export const regionEditView: EditViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/region/region.listView.ts
+++ b/databrowser/src/config/tourism/region/region.listView.ts
@@ -58,7 +58,7 @@ export const regionListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/skiArea/skiArea.description.ts
+++ b/databrowser/src/config/tourism/skiArea/skiArea.description.ts
@@ -2,6 +2,6 @@ import { DatasetDescription } from '../../../domain/datasetConfig/types';
 
 export const skiAreaDescription: DatasetDescription = {
   title: 'Ski Area',
-  subtitle: 'This dataset contains South Tyrolean Ski areas',
-  description: 'This dataset contains South Tyrolean Ski areas ',
+  subtitle: 'This dataset contains Ski areas',
+  description: 'This dataset contains Ski areas ',
 };

--- a/databrowser/src/config/tourism/skiArea/skiArea.detailView.ts
+++ b/databrowser/src/config/tourism/skiArea/skiArea.detailView.ts
@@ -168,7 +168,7 @@ export const skiAreaDetailView: DetailViewConfig = {
               fields: { text: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -453,7 +453,7 @@ export const skiAreaDetailView: DetailViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/skiArea/skiArea.editView.ts
+++ b/databrowser/src/config/tourism/skiArea/skiArea.editView.ts
@@ -168,7 +168,7 @@ export const skiAreaEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -453,7 +453,7 @@ export const skiAreaEditView: EditViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/skiArea/skiArea.listView.ts
+++ b/databrowser/src/config/tourism/skiArea/skiArea.listView.ts
@@ -58,7 +58,7 @@ export const skiAreaListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/skiRegion/skiRegion.description.ts
+++ b/databrowser/src/config/tourism/skiRegion/skiRegion.description.ts
@@ -2,6 +2,6 @@ import { DatasetDescription } from '../../../domain/datasetConfig/types';
 
 export const skiRegionDescription: DatasetDescription = {
   title: 'Ski Region',
-  subtitle: 'This dataset contains South Tyrolean Ski regions',
-  description: 'This dataset contains South Tyrolean Ski regions',
+  subtitle: 'This dataset contains Ski regions',
+  description: 'This dataset contains Ski regions',
 };

--- a/databrowser/src/config/tourism/skiRegion/skiRegion.detailView.ts
+++ b/databrowser/src/config/tourism/skiRegion/skiRegion.detailView.ts
@@ -80,7 +80,7 @@ export const skiRegionDetailView: DetailViewConfig = {
               fields: { text: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -329,7 +329,7 @@ export const skiRegionDetailView: DetailViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/skiRegion/skiRegion.editView.ts
+++ b/databrowser/src/config/tourism/skiRegion/skiRegion.editView.ts
@@ -80,7 +80,7 @@ export const skiRegionEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -329,7 +329,7 @@ export const skiRegionEditView: EditViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/skiRegion/skiRegion.listView.ts
+++ b/databrowser/src/config/tourism/skiRegion/skiRegion.listView.ts
@@ -58,7 +58,7 @@ export const skiRegionListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/snowReport/snowReport.description.ts
+++ b/databrowser/src/config/tourism/snowReport/snowReport.description.ts
@@ -2,8 +2,7 @@ import { DatasetDescription } from '../../../domain/datasetConfig/types';
 
 export const snowReportDescription: DatasetDescription = {
   title: 'Snow Report',
-  subtitle:
-    'This dataset contains detailed report of all South Tyrolean Ski Areas.',
+  subtitle: 'This dataset contains detailed report of Ski Areas.',
   description:
     'Snow Report Data dataset contains detailed report of all South Tyrolean Ski Areas. Lifts, Slopes, Ski tracks, Sledges (status and conditions) data provided by LTS (daily updated), Measuring points (snow height, last snow day) data provided by LTS (daily updated), Ski Areas basic data provided by IDM.',
 };

--- a/databrowser/src/config/tourism/snowReport/snowReport.editView.ts
+++ b/databrowser/src/config/tourism/snowReport/snowReport.editView.ts
@@ -45,7 +45,7 @@ export const snowReportEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.ToggleCell,
               fields: { enabled: 'OdhActive' },
             },

--- a/databrowser/src/config/tourism/snowReport/snowReport.listView.ts
+++ b/databrowser/src/config/tourism/snowReport/snowReport.listView.ts
@@ -88,7 +88,7 @@ export const snowReportListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/tourismAssociationList/tourismAssociationList.description.ts
+++ b/databrowser/src/config/tourism/tourismAssociationList/tourismAssociationList.description.ts
@@ -2,6 +2,6 @@ import { DatasetDescription } from '../../../domain/datasetConfig/types';
 
 export const tourismAssociationListDescription: DatasetDescription = {
   title: 'Tourism Association List',
-  subtitle: 'This dataset contains South Tyrolean Tourism Associations.',
-  description: 'This dataset contains South Tyrolean Tourism Associations.',
+  subtitle: 'This dataset contains Tourism Associations.',
+  description: 'This dataset contains Tourism Associations.',
 };

--- a/databrowser/src/config/tourism/tourismAssociationList/tourismAssociationList.detailView.ts
+++ b/databrowser/src/config/tourism/tourismAssociationList/tourismAssociationList.detailView.ts
@@ -95,7 +95,7 @@ export const tourismAssociationListDetailView: DetailViewConfig = {
               fields: { text: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -349,7 +349,7 @@ export const tourismAssociationListDetailView: DetailViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/tourismAssociationList/tourismAssociationList.editView.ts
+++ b/databrowser/src/config/tourism/tourismAssociationList/tourismAssociationList.editView.ts
@@ -95,7 +95,7 @@ export const tourismAssociationListEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -349,7 +349,7 @@ export const tourismAssociationListEditView: EditViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/tourismAssociationList/tourismAssociationList.listView.ts
+++ b/databrowser/src/config/tourism/tourismAssociationList/tourismAssociationList.listView.ts
@@ -58,7 +58,7 @@ export const tourismAssociationListListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/venue/venue.detailView.ts
+++ b/databrowser/src/config/tourism/venue/venue.detailView.ts
@@ -45,7 +45,7 @@ export const venueDetailView: DetailViewConfig = {
               fields: { text: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },

--- a/databrowser/src/config/tourism/venue/venue.editView.ts
+++ b/databrowser/src/config/tourism/venue/venue.editView.ts
@@ -45,7 +45,7 @@ export const venueEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.ToggleCell,
               fields: { enabled: 'OdhActive' },
             },

--- a/databrowser/src/config/tourism/weather/weather.description.ts
+++ b/databrowser/src/config/tourism/weather/weather.description.ts
@@ -2,6 +2,6 @@ import { DatasetDescription } from '../../../domain/datasetConfig/types';
 
 export const weatherDescription: DatasetDescription = {
   title: 'Weather',
-  subtitle: 'This dataset contains South Tyrol Weather',
-  description: 'This dataset contains South Tyrol Weather',
+  subtitle: 'This dataset contains Weather',
+  description: 'This dataset contains Weather',
 };

--- a/databrowser/src/config/tourism/weather/weather.editView.ts
+++ b/databrowser/src/config/tourism/weather/weather.editView.ts
@@ -45,7 +45,7 @@ export const weatherEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.ToggleCell,
               fields: { enabled: 'OdhActive' },
             },

--- a/databrowser/src/config/tourism/weatherDistrict/weatherDistrict.description.ts
+++ b/databrowser/src/config/tourism/weatherDistrict/weatherDistrict.description.ts
@@ -2,8 +2,6 @@ import { DatasetDescription } from '../../../domain/datasetConfig/types';
 
 export const weatherDistrictDescription: DatasetDescription = {
   title: 'Weather District',
-  subtitle:
-    'his dataset contains Live weather data for each South Tyrolean district.',
-  description:
-    'This dataset contains Live weather data for each South Tyrolean district.',
+  subtitle: 'This dataset contains Live weather data for each district.',
+  description: 'This dataset contains Live weather data for each district.',
 };

--- a/databrowser/src/config/tourism/weatherDistrict/weatherDistrict.editView.ts
+++ b/databrowser/src/config/tourism/weatherDistrict/weatherDistrict.editView.ts
@@ -45,7 +45,7 @@ export const weatherDistrictEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.ToggleCell,
               fields: { enabled: 'OdhActive' },
             },

--- a/databrowser/src/config/tourism/weatherInfo/weatherInfo.description.ts
+++ b/databrowser/src/config/tourism/weatherInfo/weatherInfo.description.ts
@@ -2,6 +2,6 @@ import { DatasetDescription } from '../../../domain/datasetConfig/types';
 
 export const weatherInfoDescription: DatasetDescription = {
   title: 'WeatherInfo',
-  subtitle: 'This dataset contains South Tyrol Weather history.',
-  description: 'This dataset contains South Tyrol Weather history.',
+  subtitle: 'This dataset contains Weather history.',
+  description: 'This dataset contains Weather history.',
 };

--- a/databrowser/src/config/tourism/weatherInfo/weatherInfo.editView.ts
+++ b/databrowser/src/config/tourism/weatherInfo/weatherInfo.editView.ts
@@ -45,7 +45,7 @@ export const weatherInfoEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.ToggleCell,
               fields: { enabled: 'OdhActive' },
             },

--- a/databrowser/src/config/tourism/weatherRealTime/weatherRealTime.editView.ts
+++ b/databrowser/src/config/tourism/weatherRealTime/weatherRealTime.editView.ts
@@ -45,7 +45,7 @@ export const weatherRealTimeEditView: EditViewConfig = {
               fields: { enabled: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.ToggleCell,
               fields: { enabled: 'OdhActive' },
             },

--- a/databrowser/src/config/tourism/webcamInfo/webcamInfo.detailView.ts
+++ b/databrowser/src/config/tourism/webcamInfo/webcamInfo.detailView.ts
@@ -55,7 +55,7 @@ export const webcamInfoDetailView: DetailViewConfig = {
               fields: { text: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },
@@ -109,7 +109,7 @@ export const webcamInfoDetailView: DetailViewConfig = {
           name: 'Tags',
           properties: [
             {
-              title: 'ODH Tags',
+              title: 'Open Data Hub Tags',
               component: CellComponent.ArrayCellTags,
               class: 'w-40',
               fields: {

--- a/databrowser/src/config/tourism/webcamInfo/webcamInfo.listView.ts
+++ b/databrowser/src/config/tourism/webcamInfo/webcamInfo.listView.ts
@@ -59,7 +59,7 @@ export const webcamInfoListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/config/tourism/wineAward/wineAward.detailView.ts
+++ b/databrowser/src/config/tourism/wineAward/wineAward.detailView.ts
@@ -65,7 +65,7 @@ export const wineAwardDetailView: DetailViewConfig = {
               fields: { text: 'Active' },
             },
             {
-              title: 'Active on ODH',
+              title: 'Active on Open Data Hub',
               component: CellComponent.StringCell,
               fields: { text: 'OdhActive' },
             },

--- a/databrowser/src/config/tourism/wineAward/wineAward.listView.ts
+++ b/databrowser/src/config/tourism/wineAward/wineAward.listView.ts
@@ -125,7 +125,7 @@ export const wineAwardListView: ListViewConfig = {
       },
     },
     {
-      title: 'ODH state',
+      title: 'Open Data Hub state',
       component: CellComponent.StateCell,
       class: 'w-36',
       fields: {

--- a/databrowser/src/pages/HomePage.vue
+++ b/databrowser/src/pages/HomePage.vue
@@ -1,9 +1,7 @@
 <template>
   <AppLayout>
     <HeroContainer>
-      <HeroTitle>
-        This is the Data Browser of the Open Data Hub of South-Tyrol.
-      </HeroTitle>
+      <HeroTitle> This is the Data Browser of the Open Data Hub. </HeroTitle>
       <HeroSubTitle>
         Explore and navigate through Open Data you need to build your next
         service.


### PR DESCRIPTION
Hey Christian,
I changed the acronyms from ODH to Open Data Hub and kept all descriptions as generic as possible by avoiding limiting the geography to South Tyrol.

Thank you,

Ilaria :)