### PR TITLE
Revert Gps type being read only

### DIFF
--- a/databrowser/src/config/tourism/measuringPoint/measuringPoint.editView.ts
+++ b/databrowser/src/config/tourism/measuringPoint/measuringPoint.editView.ts
@@ -80,7 +80,7 @@ export const measuringPointEditView: EditViewConfig = {
           properties: [
             {
               title: 'GPS type',
-              component: CellComponent.StringCell,
+              component: CellComponent.InputSingleLineCell,
               fields: {
                 text: 'GpsPoints.position.Gpstype',
               },


### PR DESCRIPTION
As we decided, we will not follow the current data browser edit view configuration, so I reverted this change