### PR TITLE
Fix inconsistent slug names and GPS data names/titles

### DIFF
--- a/databrowser/src/config/tourism/district/district.detailView.ts
+++ b/databrowser/src/config/tourism/district/district.detailView.ts
@@ -228,7 +228,7 @@ export const districtDetailView: DetailViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'GPS Data',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/district/district.editView.ts
+++ b/databrowser/src/config/tourism/district/district.editView.ts
@@ -229,7 +229,7 @@ export const districtEditView: EditViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'GPS Data',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/event/event.detailView.ts
+++ b/databrowser/src/config/tourism/event/event.detailView.ts
@@ -197,7 +197,7 @@ export const eventDetailView: DetailViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'GPS-data',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/experienceArea/experienceArea.detailView.ts
+++ b/databrowser/src/config/tourism/experienceArea/experienceArea.detailView.ts
@@ -223,7 +223,7 @@ export const experienceAreaDetailView: DetailViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'gps Data',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/gastronomy/gastronomy.detailView.ts
+++ b/databrowser/src/config/tourism/gastronomy/gastronomy.detailView.ts
@@ -379,7 +379,7 @@ export const gastronomyDetailView: DetailViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'Gps',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/gastronomy/gastronomy.editView.ts
+++ b/databrowser/src/config/tourism/gastronomy/gastronomy.editView.ts
@@ -379,7 +379,7 @@ export const gastronomyEditView: EditViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'Gps',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/metaRegion/metaRegion.detailView.ts
+++ b/databrowser/src/config/tourism/metaRegion/metaRegion.detailView.ts
@@ -229,7 +229,7 @@ export const metaRegionDetailView: DetailViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'Gps',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/metaRegion/metaRegion.editView.ts
+++ b/databrowser/src/config/tourism/metaRegion/metaRegion.editView.ts
@@ -229,7 +229,7 @@ export const metaRegionEditView: EditViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'Gps',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/municipality/municipality.detailView.ts
+++ b/databrowser/src/config/tourism/municipality/municipality.detailView.ts
@@ -242,7 +242,7 @@ export const municipalityDetailView: DetailViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'Gps',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/municipality/municipality.editView.ts
+++ b/databrowser/src/config/tourism/municipality/municipality.editView.ts
@@ -242,7 +242,7 @@ export const municipalityEditView: EditViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'Gps',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/region/region.detailView.ts
+++ b/databrowser/src/config/tourism/region/region.detailView.ts
@@ -316,7 +316,7 @@ export const regionDetailView: DetailViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'Gps',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/region/region.editView.ts
+++ b/databrowser/src/config/tourism/region/region.editView.ts
@@ -316,7 +316,7 @@ export const regionEditView: EditViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'Gps',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/skiArea/skiArea.detailView.ts
+++ b/databrowser/src/config/tourism/skiArea/skiArea.detailView.ts
@@ -424,7 +424,7 @@ export const skiAreaDetailView: DetailViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'Gps',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/skiArea/skiArea.editView.ts
+++ b/databrowser/src/config/tourism/skiArea/skiArea.editView.ts
@@ -424,10 +424,10 @@ export const skiAreaEditView: EditViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'Gps',
+      slug: 'gps-data',
       subcategories: [
         {
-          name: '',
+          name: 'GPS Data',
           properties: [
             {
               title: '',

--- a/databrowser/src/config/tourism/skiRegion/skiRegion.detailView.ts
+++ b/databrowser/src/config/tourism/skiRegion/skiRegion.detailView.ts
@@ -300,7 +300,7 @@ export const skiRegionDetailView: DetailViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'Gps',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/skiRegion/skiRegion.editView.ts
+++ b/databrowser/src/config/tourism/skiRegion/skiRegion.editView.ts
@@ -303,7 +303,7 @@ export const skiRegionEditView: EditViewConfig = {
       slug: 'Gps',
       subcategories: [
         {
-          name: '',
+          name: 'GPS Data',
           properties: [
             {
               title: '',

--- a/databrowser/src/config/tourism/tourismAssociationList/tourismAssociationList.detailView.ts
+++ b/databrowser/src/config/tourism/tourismAssociationList/tourismAssociationList.detailView.ts
@@ -320,7 +320,7 @@ export const tourismAssociationListDetailView: DetailViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'Gps',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',

--- a/databrowser/src/config/tourism/tourismAssociationList/tourismAssociationList.editView.ts
+++ b/databrowser/src/config/tourism/tourismAssociationList/tourismAssociationList.editView.ts
@@ -320,10 +320,10 @@ export const tourismAssociationListEditView: EditViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'Gps',
+      slug: 'gps-data',
       subcategories: [
         {
-          name: '',
+          name: 'GPS Data',
           properties: [
             {
               title: '',

--- a/databrowser/src/config/tourism/weatherRealTime/weatherRealTime.detailView.ts
+++ b/databrowser/src/config/tourism/weatherRealTime/weatherRealTime.detailView.ts
@@ -37,7 +37,7 @@ export const weatherRealTimeDetailView: DetailViewConfig = {
           name: 'GPS Data',
           properties: [
             {
-              title: 'GPS Data',
+              title: '',
               component: CellComponent.GpsPointsCell,
               class: 'w-48',
               fields: {

--- a/databrowser/src/config/tourism/webcamInfo/webcamInfo.detailView.ts
+++ b/databrowser/src/config/tourism/webcamInfo/webcamInfo.detailView.ts
@@ -80,7 +80,7 @@ export const webcamInfoDetailView: DetailViewConfig = {
     },
     {
       name: 'GPS Data',
-      slug: 'GPS Data',
+      slug: 'gps-data',
       subcategories: [
         {
           name: 'GPS Data',


### PR DESCRIPTION
As per title, now every GPS Data in the various configs should always look like this:
![Screenshot from 2022-11-30 20-20-45](https://user-images.githubusercontent.com/57491067/204891489-7682ac12-b4aa-45dd-a7f4-12c0e342d0f9.png)
