### PR TITLE
Venue room

### DIFF
--- a/databrowser/src/config/tourism/venue/venue.sharedView.ts
+++ b/databrowser/src/config/tourism/venue/venue.sharedView.ts
@@ -1,3 +1,4 @@
+import { CellComponent } from '../../../domain/cellComponents/types';
 import {
   DetailViewConfig,
   EditViewConfig,
@@ -29,6 +30,24 @@ export const venueSharedView = (): DetailViewConfig | EditViewConfig => ({
         {
           name: 'IDs',
           properties: [idReadOnlyCell()],
+        },
+        {
+          name: '',
+          properties: [
+            {
+              title: 'Room Details',
+              component: CellComponent.EditRoomVenueCell,
+              listFields: {
+                pathToParent: 'RoomDetails',
+                fields: {
+                  Shortname: 'Shortname',
+                  Indoor: 'Indoor',
+                  SquareMeters: 'SquareMeters',
+                },
+                attributeName: 'roomVenue',
+              },
+            },
+          ],
         },
         dataStatesSubCategory(),
         sourceSubCategory(),

--- a/databrowser/src/config/tourism/venue/venue.sharedView.ts
+++ b/databrowser/src/config/tourism/venue/venue.sharedView.ts
@@ -43,6 +43,8 @@ export const venueSharedView = (): DetailViewConfig | EditViewConfig => ({
                   Shortname: 'Shortname',
                   Indoor: 'Indoor',
                   SquareMeters: 'SquareMeters',
+                  Capacity: 'VenueSetup.0.Capacity',
+                  SetupType: 'VenueSetup.0.VenueCode',
                 },
                 attributeName: 'roomVenue',
               },

--- a/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueCell.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueCell.vue
@@ -1,0 +1,20 @@
+<template>
+  <EditListCell :items="roomVenue">
+    <template #table="{ items }">
+      <EditRoomVenueTable :items="items" />
+    </template>
+    <template #tab="{ items }">
+      <EditRoomVenueTab :items="items" />
+    </template>
+  </EditListCell>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from 'vue';
+import EditListCell from '../../utils/editList/EditListCell.vue';
+import EditRoomVenueTab from './EditRoomVenueTab.vue';
+import EditRoomVenueTable from './EditRoomVenueTable.vue';
+import { RoomVenueEntry } from './types';
+
+defineProps<{ roomVenue?: RoomVenueEntry[] | null }>();
+</script>

--- a/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueTab.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueTab.vue
@@ -1,0 +1,87 @@
+<template>
+  <EditListTab :items="items">
+    <template #tabLabel="{ index }">
+      <div class="w-full">Room {{ index + 1 }}</div>
+    </template>
+
+    <template #addItems>
+      <EditListAddButton :text="'Add new room'" @click="addEmptyItem" />
+    </template>
+
+    <template #body="{ item, index }">
+      <div class="flex flex-wrap gap-8 md:flex-nowrap">
+        <div class="basis-full md:order-1 md:basis-1/3">
+          <SubCategoryItem title="Room Name" :required="true">
+            <StringCell
+              :text="item.Shortname"
+              :editable="editable"
+              @input="updateItem(index, { Shortname: $event.target.value })"
+            />
+          </SubCategoryItem>
+          <SubCategoryItem title="Indoor" :required="true">
+            <StringCell
+              :text="item.Indoor"
+              :editable="editable"
+              @input="updateItem(index, { Indoor: $event.target.value })"
+            />
+          </SubCategoryItem>
+          <SubCategoryItem title="SquareMeters">
+            <StringCell
+              :text="item.SquareMeters"
+              :editable="editable"
+              @input="updateItem(index, { SquareMeters: $event.target.value })"
+            />
+          </SubCategoryItem>
+        </div>
+        <div class="basis-full md:order-3 md:basis-1/3">
+          <div v-if="editable" class="rounded border">
+            <div class="flex items-center justify-between bg-gray-50 py-3 px-4">
+              <span class="font-semibold">Info &amp; action</span>
+            </div>
+            <div class="divide-y p-4">
+              <div>
+                <button
+                  class="m-3 flex items-center gap-3"
+                  @click="duplicateItem(index)"
+                >
+                  <IconCopy class="text-green-500" />
+                  <span>Duplicate</span>
+                </button>
+              </div>
+              <div>
+                <button
+                  class="mx-3 mt-3 flex items-center gap-3"
+                  @click="deleteItems([index])"
+                >
+                  <IconDelete class="text-delete" />
+                  <span>Delete</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="basis-full md:order-2 md:basis-1/3"></div>
+      </div>
+    </template>
+  </EditListTab>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from 'vue';
+import EditListTab from '../../utils/editList/tab/EditListTab.vue';
+import SubCategoryItem from '../../../../datasets/category/SubCategoryItem.vue';
+import IconCopy from '../../../../../components/svg/IconCopy.vue';
+import IconDelete from '../../../../../components/svg/IconDelete.vue';
+import EditListAddButton from '../../utils/editList/EditListAddButton.vue';
+import { useInjectActionTriggers } from '../../utils/editList/actions/useActions';
+import { useInjectEditMode } from '../../utils/editList/actions/useEditMode';
+import StringCell from '../stringCell/StringCell.vue';
+import { RoomVenueEntry } from './types';
+
+defineProps<{ items: RoomVenueEntry[] }>();
+
+const { addEmptyItem, deleteItems, duplicateItem, updateItem } =
+  useInjectActionTriggers();
+
+const { editable } = useInjectEditMode();
+</script>

--- a/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueTab.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueTab.vue
@@ -19,7 +19,7 @@
             />
           </SubCategoryItem>
           <SubCategoryItem title="Indoor" :required="true">
-            <StringCell
+            <ToggleCell
               :text="item.Indoor"
               :editable="editable"
               @input="updateItem(index, { Indoor: $event.target.value })"

--- a/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueTab.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueTab.vue
@@ -32,6 +32,20 @@
               @input="updateItem(index, { SquareMeters: $event.target.value })"
             />
           </SubCategoryItem>
+          <SubCategoryItem title="Capacity">
+            <StringCell
+              :text="item.Capacity"
+              :editable="false"
+              @input="updateItem(index, { Capacity: $event.target.value })"
+            />
+          </SubCategoryItem>
+          <SubCategoryItem title="SetupType">
+            <StringCell
+              :text="item.SetupType"
+              :editable="false"
+              @input="updateItem(index, { SetupType: $event.target.value })"
+            />
+          </SubCategoryItem>
         </div>
         <div class="basis-full md:order-3 md:basis-1/3">
           <div v-if="editable" class="rounded border">

--- a/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueTable.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueTable.vue
@@ -4,12 +4,16 @@
       <col class="w-32 md:w-40" />
       <col class="w-32 md:w-40" />
       <col class="w-32 md:w-40" />
+      <col class="w-32 md:w-40" />
+      <col class="w-32 md:w-40" />
     </template>
 
     <template #tableHeader>
       <TableHeaderCell>Room name</TableHeaderCell>
       <TableHeaderCell>Indoor</TableHeaderCell>
       <TableHeaderCell>SquareMeters</TableHeaderCell>
+      <TableHeaderCell>Capacity</TableHeaderCell>
+      <TableHeaderCell>Setup Type</TableHeaderCell>
     </template>
 
     <template #tableCols="{ item }">
@@ -18,6 +22,8 @@
         <ToggleCell :enabled="item.Indoor" :editable="true" />
       </TableCell>
       <TableCell>{{ item.SquareMeters }} </TableCell>
+      <TableCell>{{ item.Capacity }} </TableCell>
+      <TableCell>{{ item.SetupType }} </TableCell>
     </template>
     <template #noItems>No rooms have been defined yet</template>
     <template #addItems>

--- a/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueTable.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueTable.vue
@@ -14,7 +14,9 @@
 
     <template #tableCols="{ item }">
       <TableCell>{{ item.Shortname }} </TableCell>
-      <TableCell>{{ item.Indoor }} </TableCell>
+      <TableCell>
+        <ToggleCell :enabled="item.Indoor" :editable="true" />
+      </TableCell>
       <TableCell>{{ item.SquareMeters }} </TableCell>
     </template>
     <template #noItems>No rooms have been defined yet</template>
@@ -32,6 +34,7 @@ import EditListTable from '../../utils/editList/table/EditListTable.vue';
 import EditListAddButton from '../../utils/editList/EditListAddButton.vue';
 import { useInjectActionTriggers } from '../../utils/editList/actions/useActions';
 import { RoomVenueEntry } from './types';
+import ToggleCell from '../toggleCell/ToggleCell.vue';
 
 defineProps<{ items: RoomVenueEntry[] }>();
 

--- a/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueTable.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/EditRoomVenueTable.vue
@@ -1,0 +1,39 @@
+<template>
+  <EditListTable :items="items">
+    <template #colGroup>
+      <col class="w-32 md:w-40" />
+      <col class="w-32 md:w-40" />
+      <col class="w-32 md:w-40" />
+    </template>
+
+    <template #tableHeader>
+      <TableHeaderCell>Room name</TableHeaderCell>
+      <TableHeaderCell>Indoor</TableHeaderCell>
+      <TableHeaderCell>SquareMeters</TableHeaderCell>
+    </template>
+
+    <template #tableCols="{ item }">
+      <TableCell>{{ item.Shortname }} </TableCell>
+      <TableCell>{{ item.Indoor }} </TableCell>
+      <TableCell>{{ item.SquareMeters }} </TableCell>
+    </template>
+    <template #noItems>No rooms have been defined yet</template>
+    <template #addItems>
+      <EditListAddButton :text="'Add new room'" @click="addEmptyItem" />
+    </template>
+  </EditListTable>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from 'vue';
+import TableHeaderCell from '../../../../../components/table/TableHeaderCell.vue';
+import TableCell from '../../../../../components/table/TableCell.vue';
+import EditListTable from '../../utils/editList/table/EditListTable.vue';
+import EditListAddButton from '../../utils/editList/EditListAddButton.vue';
+import { useInjectActionTriggers } from '../../utils/editList/actions/useActions';
+import { RoomVenueEntry } from './types';
+
+defineProps<{ items: RoomVenueEntry[] }>();
+
+const { addEmptyItem } = useInjectActionTriggers();
+</script>

--- a/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/types.ts
+++ b/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/types.ts
@@ -1,0 +1,5 @@
+export interface RoomVenueEntry {
+  Shortname?: string;
+  Indoor?: string;
+  SquareMeters?: string;
+}

--- a/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/types.ts
+++ b/databrowser/src/domain/cellComponents/components/cells/editRoomVenueCell/types.ts
@@ -2,4 +2,6 @@ export interface RoomVenueEntry {
   Shortname?: string;
   Indoor?: string;
   SquareMeters?: string;
+  Capacity?: string;
+  SetupType?: string;
 }

--- a/databrowser/src/domain/cellComponents/plugins/registerCellComponents.ts
+++ b/databrowser/src/domain/cellComponents/plugins/registerCellComponents.ts
@@ -11,6 +11,7 @@ import DateCell from '../components/cells/dateCell/DateCell.vue';
 import EditedDateCell from '../components/cells/editedDateCell/EditedDateCell.vue';
 import EditImageGalleryCell from '../components/cells/editImageGalleryCell/EditImageGalleryCell.vue';
 import EditRoomBookedCell from '../components/cells/editRoomBookedCell/EditRoomBookedCell.vue';
+import EditRoomVenueCell from '../components/cells/editRoomVenueCell/EditRoomVenueCell.vue';
 import EventDocumentCell from '../components/cells/eventDocumentCell/EventDocumentCell.vue';
 import GpsPointsCell from '../components/cells/gpsPointsCell/GpsPointsCell.vue';
 import HtmlCell from '../components/cells/htmlCell/HtmlCell.vue';
@@ -61,6 +62,7 @@ export default {
     app.component(CellComponent.EditedDateCell, EditedDateCell);
     app.component(CellComponent.EditImageGalleryCell, EditImageGalleryCell);
     app.component(CellComponent.EditRoomBookedCell, EditRoomBookedCell);
+    app.component(CellComponent.EditRoomVenueCell, EditRoomVenueCell);
     app.component(CellComponent.EventDocumentCell, EventDocumentCell);
     app.component(CellComponent.GpsPointsCell, GpsPointsCell);
     app.component(CellComponent.HtmlCell, HtmlCell);

--- a/databrowser/src/domain/cellComponents/types.ts
+++ b/databrowser/src/domain/cellComponents/types.ts
@@ -10,6 +10,7 @@ export enum CellComponent {
   EditedDateCell = 'EditedDateCell',
   EditImageGalleryCell = 'EditImageGalleryCell',
   EditRoomBookedCell = 'EditRoomBookedCell',
+  EditRoomVenueCell = 'EditRoomVenueCell',
   EventDocumentCell = 'EventDocumentCell',
   GpsPointsCell = 'GpsPointsCell',
   HtmlCell = 'HtmlCell',


### PR DESCRIPTION
Hi @gappc @sseppi @pkritzinger ,
I noticed that the Venue dataset has a Room Detail Array with useful info that is not displayed. Since the format is practically the same for the Room Booked in the Event Short dataset I created a similar table using that as a template. 
In the table, I displayed: Shortname, Indoor, and SquareMeters attributes since these seemed the most relevant and easy to show.
I inserted this table in the Main Data section after the IDs.

![Screenshot 2023-04-28 125035](https://user-images.githubusercontent.com/101118017/235129211-399ca534-131d-4319-b07b-1c9ad5640f1b.png)
