### PR TITLE
Update floating-ui lib to fix popup issue with iOS Safari

### DIFF
--- a/databrowser/package-lock.json
+++ b/databrowser/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "databrowser",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "databrowser",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "dependencies": {
-        "@floating-ui/dom": "^1.1.0",
+        "@floating-ui/dom": "^1.2.9",
         "@headlessui/vue": "^1.7.7",
         "@tailwindcss/forms": "^0.5.3",
         "@vueup/vue-quill": "^1.0.1",
@@ -135,16 +135,16 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.5.tgz",
-      "integrity": "sha512-iDdOsaCHZH/0FM0yNBYt+cJxJF9S5jrYWNtDZOiDFMiZ7uxMJ/71h8eTwoVifEAruv9p9rlMPYCGIgMjOz95FQ=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg=="
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.0.tgz",
-      "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.9.tgz",
+      "integrity": "sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==",
       "dependencies": {
-        "@floating-ui/core": "^1.0.5"
+        "@floating-ui/core": "^1.2.6"
       }
     },
     "node_modules/@headlessui/vue": {
@@ -4336,16 +4336,16 @@
       }
     },
     "@floating-ui/core": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.5.tgz",
-      "integrity": "sha512-iDdOsaCHZH/0FM0yNBYt+cJxJF9S5jrYWNtDZOiDFMiZ7uxMJ/71h8eTwoVifEAruv9p9rlMPYCGIgMjOz95FQ=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg=="
     },
     "@floating-ui/dom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.0.tgz",
-      "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.9.tgz",
+      "integrity": "sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==",
       "requires": {
-        "@floating-ui/core": "^1.0.5"
+        "@floating-ui/core": "^1.2.6"
       }
     },
     "@headlessui/vue": {

--- a/databrowser/package.json
+++ b/databrowser/package.json
@@ -10,7 +10,7 @@
     "prepare": "cd .. && husky install"
   },
   "dependencies": {
-    "@floating-ui/dom": "^1.1.0",
+    "@floating-ui/dom": "^1.2.9",
     "@headlessui/vue": "^1.7.7",
     "@tailwindcss/forms": "^0.5.3",
     "@vueup/vue-quill": "^1.0.1",


### PR DESCRIPTION
The update fixes an issue where the popup in table headers was partly out of the viewport on iOS Safari if it was initially placed to close on the right side of the viewport. The lib update fixes the issue.

Note that this problem appeared only on iOS Safari.