### PR TITLE
Fix menu overlay

### DIFF
--- a/databrowser/src/layouts/menu/OverlayMenu.vue
+++ b/databrowser/src/layouts/menu/OverlayMenu.vue
@@ -27,7 +27,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
   <Dialog
     :open="dialogOpen"
-    class="fixed top-0 z-20 w-screen p-0"
+    class="fixed top-0 z-40 w-screen p-0"
     @close="closeDialog"
   >
     <DialogOverlay


### PR DESCRIPTION
While testing the databrowser i noticed that there was a (mainly) visual bug when opening the menu whilst in a dataset view. The backdrop doesn't cover the toolbox and parts of the language picker as seen here:

![databrowser-overlay-glitch](https://github.com/noi-techpark/it.bz.opendatahub.databrowser/assets/105497721/faa2ead2-be34-44ce-ba1c-1555900509ab)

This also allows the user to interact with these parts of the ui while having the menu open.

The glitch is caused by the toolbox and the language picker having a higher z-index than the menu backdrop, that being 30, i fixed it by increasing the backdrops z-index to 40. Even though 30 would have been enough, i think it's clearer this way.

Raising the backdrops z-index doesn't seem to cause any other problems, so here the PR for the fix.