### PR TITLE
Change homepage links to the opendatahub website

### DIFF
--- a/databrowser/src/pages/HomePage.vue
+++ b/databrowser/src/pages/HomePage.vue
@@ -101,7 +101,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
               <IconMail /> Share data
             </ButtonExternalLink>
             <ButtonExternalLink
-              href="https://opendatahub.com"
+              href="https://opendatahub.com/data-access/"
               target="blank"
               :size="Size.md2col"
               :variant="Variant.ghost"
@@ -124,12 +124,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
               <IconMail /> Provide showcase
             </ButtonExternalLink>
             <ButtonExternalLink
-              href="https://opendatahub.com"
+              href="https://opendatahub.com/data-visualization/"
               target="blank"
               :size="Size.md2col"
               :variant="Variant.ghost"
             >
-              <IconExternal /> More information on sharing work
+              <IconExternal /> More information on data visualization
             </ButtonExternalLink>
           </CardActions>
         </div>


### PR DESCRIPTION
While testing the databrowser i saw that the two links regarding data sharing and data visualization at the bottom of the homepage were both directed to the opendatahub homepage, I talked to emily and we decided to change the links to point to the urls [https://opendatahub.com/data-access](https://opendatahub.com/data-access) and [https://opendatahub.com/data-visualization](https://opendatahub.com/data-visualization).