### PR TITLE
split GPS column into Longitude and Latitude columns

### DIFF
--- a/databrowser/src/config/tourism/weatherRealTime/weatherRealTime.listView.ts
+++ b/databrowser/src/config/tourism/weatherRealTime/weatherRealTime.listView.ts
@@ -25,12 +25,19 @@ export const weatherRealTimeListView: ListViewConfig = {
       },
     },
     {
-      title: 'GPS Data',
-      component: CellComponent.GpsPointsCell,
+      title: 'Latitude',
+      component: CellComponent.StringCell,
       class: 'w-48',
       fields: {
-        latitude: 'latitude',
-        longitude: 'longitude',
+        text: 'latitude',
+      },
+    },
+    {
+      title: 'Longitude',
+      component: CellComponent.StringCell,
+      class: 'w-48',
+      fields: {
+        text: 'longitude',
       },
     },
     {


### PR DESCRIPTION
Hey @gappc,
As requested in this issue: [https://github.com/noi-techpark/it.bz.opendatahub.databrowser/issues/388](url) I did the split of the GPS column in the Table View

Have a nice day,
Ilaria