### PR TITLE
Reuse badge

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,12 @@
+name: REUSE Compliance Check
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v1

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ SPDX-License-Identifier: CC0-1.0
 
 # Data Browser for the Open Data Hub
 
+[![REUSE Compliance](https://github.com/noi-techpark/it.bz.opendatahub.databrowser/actions/workflows/reuse.yml/badge.svg)](https://github.com/noi-techpark/odh-docs/wiki/REUSE#badges)
+
 This is the repository for the Open Data Hub Data Browser.
 
 ## Table of Contents


### PR DESCRIPTION
@gappc

Here the last addition regarding REUSE, it's a separate workflow checking only for reuse compliance in order to be able to generate a sort of inofficial REUSE compliance check badge. At some point we would also like to add the official one to some repositories (probably including the databrowser) but we also decided to add this badge to all repositories.