### PR TITLE
Remove hardcoded 'Beta' badge and adjust ci/cd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,7 @@ jobs:
       VITE_APP_FILE_UPLOAD_URL: "https://tourism.opendatahub.com/v1/FileUpload"
       VITE_APP_ODH_LOOKUP_BASE_URL: "https://tourism.opendatahub.com"
       VITE_APP_HOTJAR_ID: "3316285"
+      VITE_APP_ENV_BADGE: "BETA"
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/databrowser/src/layouts/AppHeader.vue
+++ b/databrowser/src/layouts/AppHeader.vue
@@ -9,7 +9,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   <div class="sticky top-0 z-10 w-full">
     <div class="bg-gray-50">
       <ContentAlignmentX class="m-auto flex w-full gap-2 px-4 py-2">
-        <TagCustom class="text-sm" type="info" text="BETA" />
         <TagCustom
           v-if="envBadge"
           class="text-sm"


### PR DESCRIPTION
The beta badge is now removed and the badge gets defined in ci/cd as described in #439