### PR TITLE
Fix wrong dataspace tag in dataset overview

### DIFF
--- a/databrowser/src/locales/en.json
+++ b/databrowser/src/locales/en.json
@@ -348,6 +348,9 @@
         "accessFull": "Full access",
         "availability": "Availability of data"
       },
+      "dataSpace": {
+        "unknown": "Unknown"
+      },
       "recordCount": {
         "availableRecords": "Available records",
         "closed": "closed",

--- a/databrowser/src/pages/datasets/overview/OverviewCardItem.vue
+++ b/databrowser/src/pages/datasets/overview/OverviewCardItem.vue
@@ -17,7 +17,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       </routerLink>
       <template #right>
         <div class="flex gap-3 md:justify-self-end">
-          <TagCustom size="xs" type="black" text="Tourism" />
+          <TagCustom
+            class="capitalize"
+            size="xs"
+            type="black"
+            :text="dataset.dataSpace ?? t('overview.info.dataSpace.unknown')"
+          />
           <OverviewTagAccess :dataset="dataset" />
         </div>
       </template>
@@ -49,8 +54,11 @@ import OverviewLinkTable from './OverviewLinkTable.vue';
 import OverviewLinkApi from './OverviewLinkApi.vue';
 import OverviewTagAccess from './OverviewTagAccess.vue';
 import { usePaths } from '../../../domain/datasets/header/usePaths';
+import { useI18n } from 'vue-i18n';
 
 defineProps<{ dataset: TourismMetaData }>();
+
+const { t } = useI18n();
 
 const { datasetOverviewForId } = usePaths();
 </script>


### PR DESCRIPTION
This PR fixes a bug in the dataset-overview page, where the dataspace tags (e.g. `Tourism`, `Mobility`) were always showing `Tourism` instead the correct dataspace (see images below).

Example URL: https://databrowser.opendatahub.testingmachine.eu/dataset-overview

![bug](https://github.com/noi-techpark/it.bz.opendatahub.databrowser/assets/5732768/57598af5-a195-4049-88fc-c1bf95e8e3a2)

