### PR TITLE
fix: add missing import for DialogOverlayTransitionChild

### DIFF
--- a/databrowser/src/components/dialog/DialogOverlay.vue
+++ b/databrowser/src/components/dialog/DialogOverlay.vue
@@ -9,3 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     <div class="fixed inset-0 bg-black/25"></div>
   </DialogOverlayTransitionChild>
 </template>
+
+<script setup lang="ts">
+import DialogOverlayTransitionChild from './DialogOverlayTransitionChild.vue';
+</script>


### PR DESCRIPTION
This PR refers to #450 