### PR TITLE
Fix bug when generating Data Browser URLs out of MetaData

### DIFF
--- a/databrowser/src/domain/metaDataConfig/tourism/types.ts
+++ b/databrowser/src/domain/metaDataConfig/tourism/types.ts
@@ -4,6 +4,7 @@
 
 export interface TourismMetaData {
   id: string;
+  baseUrl: string;
   shortname: string;
   description?: string;
   output: string;

--- a/databrowser/src/domain/metaDataConfig/tourism/useMetaDataQuery.ts
+++ b/databrowser/src/domain/metaDataConfig/tourism/useMetaDataQuery.ts
@@ -14,6 +14,7 @@ interface ODHTag {
   Self: string;
 }
 interface OdhTourismMetaData {
+  BaseUrl: string;
   ApiFilter: string[];
   Id: string;
   OdhType?: string;
@@ -61,6 +62,7 @@ const mapResponse = (datasets: OdhTourismMetaData[]): TourismMetaData[] =>
   datasets
     .map((dataset) => ({
       id: dataset.Id,
+      baseUrl: dataset.BaseUrl,
       shortname: dataset.Shortname,
       description: dataset.ApiDescription?.en,
       output: Object.values(dataset.Output ?? {}).join(', '),

--- a/databrowser/src/pages/datasets/overview/OverviewLinkTable.vue
+++ b/databrowser/src/pages/datasets/overview/OverviewLinkTable.vue
@@ -31,12 +31,19 @@ const props = defineProps<{ dataset: TourismMetaData }>();
 const { dataset } = toRefs(props);
 
 const tableLocation = computed(() => {
-  if (dataset.value == null || dataset.value.dataSpace == null) {
+  if (dataset.value == null || dataset.value.baseUrl == null) {
     return;
   }
 
-  const { dataSpace, pathSegments, apiFilter } = dataset.value;
+  // TODO: this is a very dirty hack to determine if the domain is the tourism or mobility
+  // domain. A better solution would be to have a domain property in the dataset metadata,
+  // because that way we can support other domains without code changes.
+  const domain = dataset.value.baseUrl.includes('tourism')
+    ? 'tourism'
+    : 'mobility';
 
-  return computeTableLocation(dataSpace, pathSegments, apiFilter);
+  const { pathSegments, apiFilter } = dataset.value;
+
+  return computeTableLocation(domain, pathSegments, apiFilter);
 });
 </script>

--- a/databrowser/src/pages/datasets/overview/useDatasets.ts
+++ b/databrowser/src/pages/datasets/overview/useDatasets.ts
@@ -60,6 +60,7 @@ export const useOtherDatasets = (metaDataDatasets: Ref<TourismMetaData[]>) => {
     datasetConfigs.value
       .map<TourismMetaData>((config) => ({
         id: config.route.pathSegments.join('/'),
+        baseUrl: config.baseUrl,
         access: 'unknown',
         description:
           config.description.description ?? 'No description available',


### PR DESCRIPTION
This fix is a crude hack. Unfortunately, at the moment  there is no other signal we could use to find out which API/domain is targeted. It involves hard-coding domain strings.

A better solution would be to have a domain property in the dataset metadata, because that way we can support other domains without code changes.