### PR TITLE
Use refetch from table data load

### DIFF
--- a/databrowser/src/domain/datasets/ui/tableView/TableLinks.vue
+++ b/databrowser/src/domain/datasets/ui/tableView/TableLinks.vue
@@ -75,7 +75,7 @@ import { RecordId } from '../../../datasets/types';
 import { useDatasetBaseInfoStore } from '../../config/store/datasetBaseInfoStore';
 import { useSingleRecordLocations } from '../../location/datasetViewLocation';
 import DetailsLink from './DetailsLink.vue';
-import { useEventDelete } from './utils';
+import { useEventDelete } from './useTableDelete';
 
 const { t } = useI18n();
 

--- a/databrowser/src/domain/datasets/ui/tableView/TableView.vue
+++ b/databrowser/src/domain/datasets/ui/tableView/TableView.vue
@@ -38,15 +38,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         ? t('datasets.editView.dialog.deleteDialog.commonDescriptionSingular')
         : t('datasets.editView.dialog.deleteDialog.commonDescriptionPlural')
     "
-    :confirm-button-disabled="isMutateLoading"
-    :close-button-disabled="isMutateLoading"
+    :confirm-button-disabled="isDeleting"
+    :close-button-disabled="isDeleting"
     @confirm-delete="onDelete()"
     @close="closeDeleteConfirmation()"
   />
 </template>
 
 <script setup lang="ts">
-import { watch, ref } from 'vue';
+import { watch } from 'vue';
 import { useRouter } from 'vue-router';
 import LoadingError from '../../../../components/loading/LoadingError.vue';
 import { useI18n } from 'vue-i18n';
@@ -56,10 +56,9 @@ import TableFilterHint from './filter/TableFilterHint.vue';
 import { useTableLoad } from './load/useTableLoad';
 import { useTableViewRouteQueryStore } from './tableViewRouteQueryStore';
 import TableToolBox from './toolBox/TableToolBox.vue';
-import { useEventDelete } from './utils';
 import EditListDeleteDialog from '../../../cellComponents/components/utils/editList/dialogs/EditListDeleteDialog.vue';
 
-import { useApiMutate } from '../../../api/useApi';
+import { useTableDelete } from './useTableDelete';
 
 const { t } = useI18n();
 
@@ -78,60 +77,12 @@ const {
   refetch,
 } = useTableLoad();
 
-const deleteDialog = ref({
-  // NOTE: idsToDelete set as array to facilitate further implementations
-  idsToDelete: [] as string[],
-  isVisible: false,
-});
-
-const deleteUrl = ref();
-
-const {
-  isSuccess: isMutateSuccess,
-  mutate,
-  isPending: isMutateLoading,
-} = useApiMutate(deleteUrl, {
-  method: 'delete',
-});
+const { deleteDialog, onDelete, isDeleting, closeDeleteConfirmation } =
+  useTableDelete(fullPath, refetch);
 
 // Store TableView route query in a store for later use e.g. in DetailView
 // to keep the query params when switching between DetailView and TableView.
 const { currentRoute } = useRouter();
 const { setRouteQuery } = useTableViewRouteQueryStore();
 watch(currentRoute, ({ query }) => setRouteQuery(query), { immediate: true });
-
-watch(
-  () => isMutateSuccess.value,
-  (newValue: boolean) => {
-    if (newValue) {
-      closeDeleteConfirmation();
-      refetch();
-    }
-  }
-);
-
-useEventDelete.on((id: string | undefined) => {
-  if (id) {
-    openDeleteConfirmation(id);
-  }
-});
-
-const openDeleteConfirmation = (id: string) => {
-  deleteDialog.value.isVisible = true;
-  deleteDialog.value.idsToDelete = [id];
-};
-
-const closeDeleteConfirmation = () => {
-  deleteDialog.value.isVisible = false;
-  deleteDialog.value.idsToDelete = [];
-};
-
-const onDelete = async () => {
-  const currentBaseUrl = fullPath.value?.split('?')[0];
-  for (const idToDelete of deleteDialog.value.idsToDelete) {
-    deleteUrl.value = `${currentBaseUrl}/${idToDelete}`;
-
-    mutate();
-  }
-};
 </script>

--- a/databrowser/src/domain/datasets/ui/tableView/load/useTableLoad.ts
+++ b/databrowser/src/domain/datasets/ui/tableView/load/useTableLoad.ts
@@ -4,7 +4,6 @@
 
 import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
-import { useRouter } from 'vue-router';
 import { useDatasetBaseInfoStore } from '../../../config/store/datasetBaseInfoStore';
 import { updateDatasetLocationStore } from '../../../location/store/utils';
 import { useDatasetPermissionStore } from '../../../permission/store/datasetPermissionStore';
@@ -12,12 +11,8 @@ import { useDatasetViewStore } from '../../../view/store/datasetViewStore';
 import { useTableCols } from './tableCols';
 import { useTableRows } from './tableRows';
 import { useTableLoadData } from './useTableLoadData';
-import { randomId } from '../../../../../components/utils/random';
 
 export const useTableLoad = () => {
-  const router = useRouter();
-  const { currentRoute } = router;
-
   // Use base dataset info
   const {
     isLoading: isConfigLoading,
@@ -28,11 +23,8 @@ export const useTableLoad = () => {
   } = storeToRefs(useDatasetBaseInfoStore());
 
   // Load table data
-  const { isDataLoading, isError, error, data, pagination } = useTableLoadData(
-    datasetDomain,
-    datasetQuery,
-    fullPath
-  );
+  const { isDataLoading, isError, error, data, pagination, refetch } =
+    useTableLoadData(datasetDomain, datasetQuery, fullPath);
 
   updateDatasetLocationStore(datasetDomain, datasetPath, datasetQuery, data);
 
@@ -56,14 +48,6 @@ export const useTableLoad = () => {
   const { editRecordSupported, deleteRecordSupported } = storeToRefs(
     useDatasetPermissionStore()
   );
-
-  const refetch = () => {
-    setTimeout(() =>
-      router.replace({
-        query: { ...currentRoute.value.query, refetchId: randomId() },
-      })
-    );
-  };
 
   return {
     isLoading,

--- a/databrowser/src/domain/datasets/ui/tableView/load/useTableLoadData.ts
+++ b/databrowser/src/domain/datasets/ui/tableView/load/useTableLoadData.ts
@@ -15,7 +15,7 @@ export const useTableLoadData = (
   fullPath: MaybeRef<string | undefined>
 ) => {
   // Fetch data
-  const { data, error, isError, isLoading } = useApiRead(fullPath, {
+  const { data, error, isError, isLoading, refetch } = useApiRead(fullPath, {
     withAuth: true,
   });
 
@@ -34,5 +34,6 @@ export const useTableLoadData = (
     error,
     isError,
     isDataLoading: isLoading,
+    refetch,
   };
 };

--- a/databrowser/src/domain/datasets/ui/tableView/useTableDelete.ts
+++ b/databrowser/src/domain/datasets/ui/tableView/useTableDelete.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { watch, ref, Ref } from 'vue';
+import { useEventBus } from '@vueuse/core';
+import { useApiMutate } from '../../../api/useApi';
+
+export const useEventDelete = useEventBus<string | undefined>('delete');
+
+export const useTableDelete = (
+  fullPath: Ref<string | undefined>,
+  refetch: () => void
+) => {
+  const deleteDialog = ref({
+    // NOTE: idsToDelete set as array to facilitate further implementations
+    idsToDelete: [] as string[],
+    isVisible: false,
+  });
+
+  const deleteUrl = ref();
+
+  const {
+    isSuccess: isMutateSuccess,
+    mutate,
+    isPending: isDeleting,
+  } = useApiMutate(deleteUrl, {
+    method: 'delete',
+  });
+
+  watch(
+    () => isMutateSuccess.value,
+    (newValue: boolean) => {
+      if (newValue) {
+        closeDeleteConfirmation();
+        refetch();
+      }
+    }
+  );
+
+  useEventDelete.on((id: string | undefined) => {
+    if (id) {
+      openDeleteConfirmation(id);
+    }
+  });
+
+  const openDeleteConfirmation = (id: string) => {
+    deleteDialog.value.isVisible = true;
+    deleteDialog.value.idsToDelete = [id];
+  };
+
+  const closeDeleteConfirmation = () => {
+    deleteDialog.value.isVisible = false;
+    deleteDialog.value.idsToDelete = [];
+  };
+
+  const onDelete = async () => {
+    const currentBaseUrl = fullPath.value?.split('?')[0];
+    for (const idToDelete of deleteDialog.value.idsToDelete) {
+      deleteUrl.value = `${currentBaseUrl}/${idToDelete}`;
+
+      mutate({});
+    }
+  };
+
+  return {
+    deleteDialog,
+    onDelete,
+    isDeleting,
+    closeDeleteConfirmation,
+  };
+};

--- a/databrowser/src/domain/datasets/ui/tableView/utils.ts
+++ b/databrowser/src/domain/datasets/ui/tableView/utils.ts
@@ -1,7 +1,0 @@
-// SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
-import { useEventBus } from '@vueuse/core';
-
-export const useEventDelete = useEventBus<string | undefined>('delete');


### PR DESCRIPTION
@a-crea this PR builds upon your PR #499 and adds a single change: the `refetch` function now comes from the table data loader (in effect, it comes from the underlying useQuery). That way we don't need to set the URL query param  - nice idea btw ;)

The important changes can be found here:

https://github.com/noi-techpark/it.bz.opendatahub.databrowser/commit/1bdb4fb128224a855f04d05c0349027802ef1f31#diff-dd92aee5aa9e0482de571eb6a2370cbb07a5a21876eaa328b7f1956a97bb1a29R18

and

https://github.com/noi-techpark/it.bz.opendatahub.databrowser/commit/1bdb4fb128224a855f04d05c0349027802ef1f31#diff-6c6021849e6fff84340b416a6146e8d9000555c2a2ca55a28ae5a05b8ba5dee6R29-R52

The rest of PR #499 looks good to me.

If the changes are ok for you, we could take the shortcut and just merge this PR