### PR TITLE
Do not commit code that contains linting warnings

### DIFF
--- a/databrowser/package.json
+++ b/databrowser/package.json
@@ -5,8 +5,8 @@
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
     "serve": "vite preview",
-    "lint": "eslint --cache --ext .ts,.vue src",
-    "lint:fix": "eslint --cache --ext .ts,.vue --fix src",
+    "lint": "eslint --cache --max-warnings 0 --ext .ts,.vue src",
+    "lint:fix": "eslint --cache --max-warnings 0 --ext .ts,.vue --fix src",
     "prepare": "cd .. && husky install"
   },
   "dependencies": {


### PR DESCRIPTION
This PR adds the option "--max-warnings 0" to eslint. That option prevents commits if the code-to-commit contains linting warnings.

This PR solves issue #371 