### PR TITLE
Fix cancel / save button position for mobile view

### DIFF
--- a/databrowser/src/domain/datasets/ui/editView/EditView.vue
+++ b/databrowser/src/domain/datasets/ui/editView/EditView.vue
@@ -54,7 +54,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
           <EditToolBox />
         </div>
         <EditFooter
-          class="transition-all"
+          class="sticky bottom-0 transition-all"
           :is-saving="isMutateLoading"
           :class="{ hidden: editStore.isEqual }"
           @cancel="tryToDiscardChanges"


### PR DESCRIPTION
The cancel / save buttons in the EditView were visible only at the bottom of the mobile view.

Depending on the height of the page, they were only visible after a user scrolled down.

This commit fixes that issue.