### PR TITLE
Fix partner logo of Christian Gapp

### DIFF
--- a/databrowser/public/logo-gapp.svg
+++ b/databrowser/public/logo-gapp.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="62.083462mm"
+   height="34.227173mm"
+   viewBox="0 0 219.98077 121.27738"
+   id="svg2"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(-429.34404,-611.46013)">
+    <g
+       id="g5258">
+      <path
+         d="m 530.69131,716.09645 a 64.285713,55 0 0 1 -84.35896,-12.2255 64.285713,55 0 0 1 4.55411,-73.09812 64.285713,55 0 0 1 85.39998,-4.48398"
+         id="path4168-3"
+         style="opacity:1;fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:6;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         d="m 524.90273,707.4931 a 52.4487,44.87278 0 0 1 -68.82583,-9.9744 52.4487,44.87278 0 0 1 3.71556,-59.63848 52.4487,44.87278 0 0 1 69.67517,-3.65833"
+         id="path4168-7-6"
+         style="opacity:1;fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:4.89521;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         d="m 516.33717,699.75264 a 39.766186,34.022186 0 0 1 -52.18319,-7.56252 39.766186,34.022186 0 0 1 2.8171,-45.21741 39.766186,34.022186 0 0 1 52.82716,-2.77372"
+         id="path4168-5-0"
+         style="opacity:1;fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:3.71151;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <text
+         id="text4808"
+         y="685.2193"
+         x="474.28568"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="685.2193"
+           x="474.28568"
+           id="tspan4810"
+           style="font-size:40px;line-height:1.25">Christian</tspan></text>
+      <text
+         id="text4808-1"
+         y="724.41718"
+         x="545.22321"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="724.41718"
+           x="545.22321"
+           id="tspan4810-8"
+           style="font-size:40px;line-height:1.25">Gapp</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/databrowser/src/components/partners/PartnersAndContributors.vue
+++ b/databrowser/src/components/partners/PartnersAndContributors.vue
@@ -59,8 +59,7 @@ const partners: Partner[] = [
   },
   {
     imageAlt: 'Christian Gapp company logo',
-    imageSrc:
-      'https://gappc.net/wp-content/uploads/2022/10/logo-full-black.png',
+    imageSrc: '/logo-gapp.svg',
     linkTitle: 'Christian Gapp homepage',
     url: 'https://gappc.net/',
   },


### PR DESCRIPTION
The logo was referenced from https://gappc.net, but that site changed a bit. Now the logo is part of this project (SVG, ~4KB), like the other partner logos.