### PR TITLE
Add number support to InputCustom and StringCell

### DIFF
--- a/databrowser/src/components/input/InputCustom.vue
+++ b/databrowser/src/components/input/InputCustom.vue
@@ -53,6 +53,7 @@ import IconSearch from '../svg/IconSearch.vue';
 import IconClose from '../svg/IconClose.vue';
 
 import { useEventDelete } from './utils';
+import { InputType } from './types';
 
 const id = randomId();
 
@@ -67,7 +68,7 @@ const props = defineProps<{
   deletable?: boolean;
   hasLabelTop?: boolean;
   disabled?: boolean;
-  type?: 'text' | 'date' | 'datetime-local' | 'time' | 'search';
+  type?: InputType;
 }>();
 
 const inputRef = ref();

--- a/databrowser/src/components/input/types.ts
+++ b/databrowser/src/components/input/types.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export type InputType =
+  | 'date'
+  | 'datetime-local'
+  | 'email'
+  | 'month'
+  | 'number'
+  | 'search'
+  | 'tel'
+  | 'text'
+  | 'time'
+  | 'url'
+  | 'week';

--- a/databrowser/src/domain/cellComponents/components/cells/stringCell/StringCell.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/stringCell/StringCell.vue
@@ -11,6 +11,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     :model-value="text"
     :deletable="deletable"
     :placeholder="placeholder"
+    :type="type"
     @update:model-value="update($event)"
   />
   <span
@@ -28,6 +29,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import { toRefs } from 'vue';
 import InputCustom from '../../../../../components/input/InputCustom.vue';
 import { useWriteable } from '../../utils/writeable/useWriteable';
+import { InputType } from '../../../../../components/input/types';
 
 const emit = defineEmits(['update']);
 
@@ -39,6 +41,7 @@ const props = defineProps<{
   readonly?: string | boolean;
   placeholder?: string;
   textClasses?: string;
+  type?: InputType;
 }>();
 
 const { editable, readonly } = toRefs(props);


### PR DESCRIPTION
This commit adds support for numbers (among others) to the  `InputCustom` and `StringCell`.

Example usage of StringCell in config:

```json
{
  title: 'Age',
  component: CellComponent.StringCell,
  objectMapping: { text: 'Age' },
  params: { type: 'number' }
}
```

In essence, you can set the `type` in the `params` property of the `StringCell`. That type will be promoted 1:1 to the underlying `input` HTML element.