### PR TITLE
Use env variable to set content of robots meta tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ jobs:
       VITE_APP_FILE_UPLOAD_URL: "https://api.tourism.testingmachine.eu/v1/FileUpload/"
       VITE_APP_ODH_LOOKUP_BASE_URL: "https://api.tourism.testingmachine.eu"
       VITE_APP_ENV_BADGE: "TESTING"
+      VITE_APP_META_ROBOTS: "<meta name=\"robots\" content=\"noindex, nofollow\" />"
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -137,6 +138,7 @@ jobs:
       VITE_APP_IMAGE_UPLOAD_URL: "https://tourism.opendatahub.com/v1/FileUpload/Image"
       VITE_APP_FILE_UPLOAD_URL: "https://tourism.opendatahub.com/v1/FileUpload"
       VITE_APP_ODH_LOOKUP_BASE_URL: "https://tourism.opendatahub.com"
+      VITE_APP_META_ROBOTS: ""
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/databrowser/.env.example
+++ b/databrowser/.env.example
@@ -6,3 +6,4 @@ VITE_APP_IMAGE_UPLOAD_URL=https://api.tourism.testingmachine.eu/v1/FileUpload/Im
 VITE_APP_FILE_UPLOAD_URL=https://api.tourism.testingmachine.eu/v1/FileUpload
 VITE_APP_ODH_LOOKUP_BASE_URL=https://api.tourism.testingmachine.eu
 VITE_APP_ENV_BADGE=TESTING
+VITE_APP_META_ROBOTS=

--- a/databrowser/index.html
+++ b/databrowser/index.html
@@ -13,11 +13,12 @@ SPDX-License-Identifier: CC0-1.0
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
-    <meta name="robots" content="noindex, nofollow" />
     <meta name="msapplication-TileColor" content="#da532c" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Data Browser for Open Data Hub</title>
+
+    %VITE_APP_META_ROBOTS%
 
     <!-- Matomo -->
     <script type="text/plain" data-cookiecategory="targeting">


### PR DESCRIPTION
The content of robots meta tag is now taken from the VITE_APP_META_ROBOTS environment variable.

This mechanism uses vite's env variable replacement.