### PR TITLE
Add options to array editable cell

### DIFF
--- a/databrowser/src/domain/cellComponents/components/cells/arrayCell/ArrayEditableCell.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/arrayCell/ArrayEditableCell.vue
@@ -6,15 +6,16 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <template>
   <EditListCell :items="items">
-    <!-- eslint-disable-next-line vue/no-template-shadow -->
     <template #table="{ items }">
-      <ArrayEditableTable :items="items" />
+      <ArrayEditableTable :items="items" :options="options" />
     </template>
   </EditListCell>
 </template>
 
 <script setup lang="ts">
+import { useAttrs } from 'vue';
 import EditListCell from '../../utils/editList/EditListCell.vue';
+import { useAttributeMapper } from '../tagCell/useAttributeMapper';
 import ArrayEditableTable from './ArrayEditableTable.vue';
 
 withDefaults(
@@ -23,6 +24,11 @@ withDefaults(
   }>(),
   {
     items: () => [],
+    options: () => [],
   }
 );
+
+const attrs = useAttrs();
+
+const { options } = useAttributeMapper(attrs, true);
 </script>

--- a/databrowser/src/domain/cellComponents/components/cells/arrayCell/ArrayEditableTable.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/arrayCell/ArrayEditableTable.vue
@@ -17,7 +17,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     <template #tableCols="{ item, index }">
       <TableCell>
         <StringCell
+          v-if="!hasOptions"
           :text="item"
+          :editable="editable"
+          @update="updateItem(index, $event.value)"
+        />
+        <SelectWithOptionsCell
+          v-else
+          :options="options"
+          :value="item"
           :editable="editable"
           @update="updateItem(index, $event.value)"
         />
@@ -38,10 +46,20 @@ import EditListAddButton from '../../utils/editList/EditListAddButton.vue';
 import { useInjectActionTriggers } from '../../utils/editList/actions/useActions';
 import { useInjectEditMode } from '../../utils/editList/actions/useEditMode';
 import StringCell from '../stringCell/StringCell.vue';
+import { SelectOption } from '../../../../../components/select/types';
+import { computed } from 'vue';
+import SelectWithOptionsCell from '../selectWithOptionsCell/SelectWithOptionsCell.vue';
 
-defineProps<{ items: string[] }>();
+const props = defineProps<{
+  items: string[];
+  options?: SelectOption[];
+}>();
 
 const { editable } = useInjectEditMode();
+
+const hasOptions = computed(
+  () => props.options != null && props.options.length > 0
+);
 
 const { addItems, updateItem } = useInjectActionTriggers<string>();
 </script>

--- a/databrowser/src/domain/cellComponents/components/cells/tagCell/TagCell.vue
+++ b/databrowser/src/domain/cellComponents/components/cells/tagCell/TagCell.vue
@@ -18,7 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script setup lang="ts">
-import { computed, ref, toRefs, useAttrs } from 'vue';
+import { computed, toRefs, useAttrs } from 'vue';
 import EditListCell from '../../utils/editList/EditListCell.vue';
 import TagTable from './TagTable.vue';
 import { useAttributeMapper } from './useAttributeMapper';
@@ -40,7 +40,7 @@ const { tags, sortByLabel, unique } = toRefs(props);
 
 const attrs = useAttrs();
 
-const { options } = useAttributeMapper(ref(attrs), sortByLabel);
+const { options } = useAttributeMapper(attrs, sortByLabel);
 
 const enableUniqueValue = computed(() => {
   // if unique is a boolean, return it

--- a/databrowser/src/domain/cellComponents/components/cells/tagCell/useAttributeMapper.ts
+++ b/databrowser/src/domain/cellComponents/components/cells/tagCell/useAttributeMapper.ts
@@ -2,9 +2,13 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { ref, Ref, watch } from 'vue';
+import { MaybeRef, ref, Ref, toValue, watch } from 'vue';
 import { SelectOption } from '../../../../../components/select/types';
-import { buildOptions, mapToOptionsWithKeys, mapToOptionsWithKeysAndValues } from '../../utils/selectOptions/selectOptionsMapperUtils';
+import {
+  buildOptions,
+  mapToOptionsWithKeys,
+  mapToOptionsWithKeysAndValues,
+} from '../../utils/selectOptions/selectOptionsMapperUtils';
 
 // The select options are provided as attributes of form
 // "value_XXX" and "label_XXX"; they must be transformed in
@@ -14,21 +18,24 @@ import { buildOptions, mapToOptionsWithKeys, mapToOptionsWithKeysAndValues } fro
 // value "Eurac" are merged into the following SelectOption:
 // {value: "EC", label: "Eurac"}
 export const useAttributeMapper = (
-  attrs: Ref<Record<string, unknown>>,
-  sortByLabel: Ref<boolean>
-) => {
+  attrs: MaybeRef<Record<string, unknown>>,
+  sortByLabel: MaybeRef<boolean>
+): { options: Ref<SelectOption[]> } => {
   const options = ref<SelectOption[]>([]);
 
   watch(
-    () => [attrs.value],
+    () => [toValue(attrs)],
     () => {
-      const optionsWithKeys = mapToOptionsWithKeys(attrs.value);
+      const attrsValue = toValue(attrs);
+      const sortByLabelValue = toValue(sortByLabel);
+
+      const optionsWithKeys = mapToOptionsWithKeys(attrsValue);
       const optionsWithKeysAndValues = mapToOptionsWithKeysAndValues(
-        attrs.value,
+        attrsValue,
         optionsWithKeys
       );
 
-      options.value = buildOptions(optionsWithKeysAndValues, sortByLabel.value);
+      options.value = buildOptions(optionsWithKeysAndValues, sortByLabelValue);
     },
     { immediate: true }
   );


### PR DESCRIPTION
This PR adds support for predefined options to the `ArrayEditableCell`, it implements the missing feature from issue #547